### PR TITLE
Add make-specialized-array-from-data, list*->array, and vector*->array

### DIFF
--- a/231.sld
+++ b/231.sld
@@ -93,6 +93,8 @@
     array-every
     array->list
     list->array
+    list*->array
+    vector*->array
     array-assign!
     array-copy
     array-append

--- a/231.sld
+++ b/231.sld
@@ -37,6 +37,8 @@
     storage-class-copier
     storage-class-length
     storage-class-default
+    storage-class-data?
+    storage-class-data->body
     generic-storage-class
     s8-storage-class
     s16-storage-class
@@ -65,6 +67,7 @@
     specialized-array-default-safe?
     specialized-array-default-mutable?
     make-specialized-array
+    make-specialized-array-from-data
     specialized-array?
     array-storage-class
     array-indexer

--- a/srfi-231.html
+++ b/srfi-231.html
@@ -125,13 +125,7 @@
     <h2>Issues</h2>
     <ul>
       <li>Should eager comprehensions in the style of <a href="https://srfi.schemers.org/srfi-42/">SRFI 42</a> be added to this SRFI, as <a href="https://srfi-email.schemers.org/srfi-179/msg/18428002/">suggested</a> by Jens Axel S&#248;gaard?  My opinion is yes, but I would need major help in designing and implementing such things.</li>
-      <li>Should <a href="#specialized-array-default-mutable?"><code>specialized-array-default-mutable?</code></a> and <a href="#specialized-array-default-safe?"><code>specialized-array-default-safe?</code></a> be <a href="https://srfi.schemers.org/srfi-39/">SRFI 39</a> parameters or <a href="https://small.r7rs.org/attachment/r7rs.pdf">R7RS</a> parameters? Or would some other way of specifying, and changing, the default safety and mutability of specialized arrays be better?</li>
       <li>Could <a href="#array-elements-in-order?"><code>array-elements-in-order?</code></a> have a better name or description?</li>
-      <li>The naming convention is not entirely uniform; most array functions begin with <code>array-</code> but there are also 
-        <ul>
-          <li><code>make-array</code>, <code>make-interval</code>, <code>make-storage-class</code>, and <code>make-specialized-array</code></li>
-          <li><code>mutable-array?</code></li>
-        </ul>All other operations begin with the name of the objects that they take as arguments, or that they return.  The question is whether we should change these few names.</li>
     </ul>
     <h2>Notes</h2>
     <ul>
@@ -144,7 +138,6 @@
       <li><b>Choice of procedures on intervals. </b>The choice of procedures for both arrays and intervals was motivated almost solely by what I needed for arrays.</li>
       <li><b>No empty intervals. </b>This SRFI considers arrays over only nonempty intervals of positive dimension.  The author of this proposal acknowledges that other languages and array systems allow either zero-dimensional intervals or empty intervals of positive dimension, but prefers to leave such empty intervals as possibly compatible extensions to the current proposal.</li>
       <li><b>Multi-valued arrays. </b>While this SRFI restricts attention to single-valued arrays, wherein the getter of each array returns a single value, allowing multi-valued immutable arrays would be a compatible extension of this SRFI.</li>
-      <li><b>No low-level specialized array constructor. </b>While the author of the SRFI uses mainly <code>(make-array ...)</code>, <code>array-map</code>, and <code>array-copy</code> to construct arrays, and while there are several other ways to construct arrays, there is no really low-level interface given for constructing specialized arrays (where one specifies a body, an indexer, etc.).  It was felt that certain difficulties, some surmountable (such as checking that a given body is compatible with a given storage class) and some not (such as checking that an indexer is indeed affine), made a low-level interface less useful.  At the same time, the simple <code>(make-array ...)</code> mechanism is so general, allowing one to specify getters and setters as general procedures, as to cover nearly all needs.</li>
     </ul>
     <h2>Specification</h2>
     <dl>

--- a/srfi-231.html
+++ b/srfi-231.html
@@ -45,7 +45,7 @@
       <li>If the first argument to <code>array-copy</code> is a specialized array, then omitted arguments are taken from the argument array and do not default to <code>generic-storage-class</code>, <code>(specialized-array-default-mutable?)</code>, and <code>(specialized-array-default-safe?)</code>.  Thus, by default, <code>array-copy</code> makes a true copy of a specialized array.</li>
       <li>Procedures that generate useful permutations have been added: <code>index-rotate</code>, <code>index-first</code>, and <code>index-last</code>.</li>
       <li><code>interval-rotate</code> and <code>array-rotate</code> have been removed; use <code>(array-permute A (index-rotate (array-dimension A) k))</code> instead of <code>(array-rotate A k)</code>.</li>
-      <li>Introduced new routines <code>array-inner-product</code>, <code>array-stack</code>, and <code>array-append</code>.</li>
+      <li>Introduced new routines <code>storage-class-data?</code>, <code>storage-class-data-&gt;body</code>, <code>make-specialized-array-from-data</code>, <code>array-inner-product</code>, <code>array-stack</code>, and <code>array-append</code>.</li>
       <li>A new set of &quot;Introductory remarks&quot; surveys some of the more important procedures in this SRFI.</li>
     </ul>
     <h2>Overview</h2>
@@ -186,6 +186,8 @@
         <a href="#storage-class-copier">storage-class-copier</a>,
         <a href="#storage-class-length">storage-class-length</a>,
         <a href="#storage-class-default">storage-class-default</a>,
+        <a href="#storage-class-data?">storage-class-data?</a>,
+        <a href="#storage-class-data-rarrow-body">storage-class-data-&gt;body</a>,
         <a href="#generic-storage-class">generic-storage-class</a>,
         <a href="#s8-storage-class">s8-storage-class</a>,
         <a href="#s16-storage-class">s16-storage-class</a>,
@@ -213,6 +215,7 @@
         <a href="#mutable-array?">mutable-array?</a>,
         <a href="#array-setter">array-setter</a>,
         <a href="#make-specialized-array">make-specialized-array</a>,
+        <a href="#make-specialized-array-from-data">make-specialized-array-from-data</a>,
         <a href="#specialized-array?">specialized-array?</a>,
         <a href="#array-storage-class">array-storage-class</a>,
         <a href="#array-indexer">array-indexer</a>,
@@ -453,7 +456,7 @@
     <p>Conceptually, a storage-class is a set of procedures to manage the backing store of a specialized array.
       The procedures allow one to make a backing store, to get values from the store and to set new values, to return the length of the store, and to specify a default value for initial elements of the backing store.  Typically, a backing store is a (heterogeneous or homogeneous) vector.  A storage-class has a type distinct from other Scheme types.</p>
     <h3>Procedures</h3>
-    <p><b>Procedure: </b><code><a id="make-storage-class">make-storage-class</a> <var>getter</var> <var>setter</var> <var>checker</var> <var>maker</var> <var>copier</var> <var>length</var> <var>default</var></code></p>
+    <p><b>Procedure: </b><code><a id="make-storage-class">make-storage-class</a> <var>getter</var> <var>setter</var> <var>checker</var> <var>maker</var> <var>copier</var> <var>length</var> <var>default</var> <var>data?</var> <var>data-&gt;body</var></code></p>
     <p>Here we assume the following relationships between the arguments of <code>make-storage-class</code>.  Assume that the &quot;elements&quot; of
       the backing store are of some &quot;type&quot;, either heterogeneous (all Scheme types) or homogeneous (of some restricted type).</p>
     <ul>
@@ -462,6 +465,7 @@
       <li>If <code><var>v</var></code> is an object created by <code>(<var>maker n value</var>)</code> and  0 &lt;= <code><var>i</var></code> &lt; <code><var>n</var></code>, then <code>(<var>getter v i</var>)</code> returns the current value of the <code><var>i</var></code>'th element of <code><var>v</var></code>, and <code>(<var>checker</var> (<var>getter v i</var>)) =&gt; #t</code>.</li>
       <li>If <code><var>v</var></code> is an object created by <code>(<var>maker n value</var>)</code>,  0 &lt;= <code><var>i</var></code> &lt; <code><var>n</var></code>, and <code>(<var>checker</var> <var>val</var>) =&gt; #t</code>, then <code>(<var>setter v i val</var>)</code> sets the value of the <code><var>i</var></code>'th element of  <code><var>v</var></code> to <code><var>val</var></code>.</li>
       <li>If <code><var>v</var></code> is an object created by <code>(<var>maker n value</var>)</code> then <code>(<var>length v</var>)</code> returns <code><var>n</var></code>.</li>
+      <li>The <code><var>data?</var></code> and <code><var>data-&gt;body</var></code> entries are low-level routines. <code>((storage-class-data? <var>storage-class</var>) <var>data</var>)</code> returns <code>#t</code> if and only if <code>((storage-class-data-&gt;body <var>storage-class</var>) <var>data</var>)</code> returns a body sharing data with <code><var>data</var></code>, without copying.  See the discussion of <code>make-specialized-array-from-data</code>.</li>
     </ul>
     <p>If the arguments do not satisfy these conditions, then it is an error to call <code>make-storage-class</code>.</p>
     <p>Note that we assume that <code><var>getter</var></code> and <code><var>setter</var></code> generally take <i>O</i>(1) time to execute.</p>
@@ -474,10 +478,12 @@
     <p><b>Procedure: </b><code><a id="storage-class-copier">storage-class-copier</a> <var>m</var></code></p>
     <p><b>Procedure: </b><code><a id="storage-class-length">storage-class-length</a> <var>m</var></code></p>
     <p><b>Procedure: </b><code><a id="storage-class-default">storage-class-default</a> <var>m</var></code></p>
+    <p><b>Procedure: </b><code><a id="storage-class-data?">storage-class-data?</a> <var>m</var></code></p>
+    <p><b>Procedure: </b><code><a id="storage-class-data-rarrow-body">storage-class-data-&gt;body</a> <var>m</var></code></p>
     <p>If <code><var>m</var></code> is an object created by</p>
-    <blockquote><code>(make-storage-class <var>getter setter checker maker copier length default</var>)</code>
+    <blockquote><code>(make-storage-class <var>getter setter checker maker copier length default data? data-&gt;body</var>)</code>
     </blockquote>
-    <p> then <code>storage-class-getter</code> returns <code><var>getter</var></code>, <code>storage-class-setter</code> returns <code><var>setter</var></code>, <code>storage-class-checker</code> returns <code><var>checker</var></code>, <code>storage-class-maker</code> returns <code><var>maker</var></code>, <code>storage-class-copier</code> returns <code><var>copier</var></code>, <code>storage-class-length</code> returns <code><var>length</var></code>, and <code>storage-class-default</code> returns <code><var>default</var></code>.  Otherwise, it is an error to call any of these procedures.</p>
+    <p> then <code>storage-class-getter</code> returns <code><var>getter</var></code>, <code>storage-class-setter</code> returns <code><var>setter</var></code>, <code>storage-class-checker</code> returns <code><var>checker</var></code>, <code>storage-class-maker</code> returns <code><var>maker</var></code>, <code>storage-class-copier</code> returns <code><var>copier</var></code>, <code>storage-class-length</code> returns <code><var>length</var></code>,  <code>storage-class-default</code> returns <code><var>default</var></code>, <code>storage-class-data?</code> returns <code><var>data?</var></code>, and <code>storage-class-data-&gt;body</code> returns <code><var>data-&gt;body</var></code>.  Otherwise, it is an error to call any of these procedures.</p>
     <h3>Global Variables</h3>
     <p><b>Variable: </b><code><a id="generic-storage-class">generic-storage-class</a></code></p>
     <p><b>Variable: </b><code><a id="s8-storage-class">s8-storage-class</a></code></p>
@@ -640,6 +646,46 @@
     (make-specialized-array interval u16-storage-class 0 #f))
 </code></pre>
     <p>and then simply call, e.g., <code>(make-u16-array (make-interval '#(3 3)))</code>.</p>
+    <p><b>Procedure: </b><code><a id="make-specialized-array-from-data">make-specialized-array-from-data</a> <var>data</var> [ <var>storage-class</var> generic-storage-class ] [ <var>mutable?</var> (specialized-array-default-mutable?) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
+    <p>This routine constructs a new specialized array using <code><var>data</var></code> as part of the body of the result without copying.</p>
+    <p>This routine exploits the low-level representation of the body of a specialized array of a specific storage class, and as such may not be portable between implementations.  Here are several examples.</p>
+    <p>The reference implementation uses homogeneous vectors to represent the bodies of arrays with storage classes <code>u8-storage-class</code>, <code>s8-storage-class</code>, ..., <code>s64-storage-class</code>, <code>f32-storage-class</code>, and <code>f64-storage-class</code>.  Another implementation might use byte-vectors as the bodies of arrays for all these storage classes.</p>
+    <p>The reference implementation uses homogeneous (f32 and f64) vectors with an even number of elements to represent the bodies of arrays with storage classes <code>c64-storage-class</code> and <code>c128-storage-class</code>. Another implementation with purely inexact complex numbers might make another choice.</p>
+    <p>Finally, the reference implementation uses <code>(vector <var>n</var> (u16vector ...))</code> to represent the body of an array with a <code>u1-storage-class</code>, where <code><var>n</var></code> represents the valid number of bits (no more than 16 times the length of the <code>u16vector</code>).  A Scheme with bitvectors might choose those as the underlying representation of bodies of arrays with <code>u1-storage-class</code>.</p>
+    <p>This routine assumes that <code><var>mutable?</var></code> and <code><var>safe?</var></code>, if given, are booleans, and that <code><var>storage-class</var></code>, if given, is a storage class.  <code><var>data</var></code> must be an object for which <code>((storage-class-data? <var>storage-class</var>) <var>data</var>)</code> returns <code>#t</code>.</p>
+    <p>This routine constructs a new one-dimensional array with storage class <code><var>storage-class</var></code>, mutability <code><var>mutable?</var></code>, safety <code><var>safe?</var></code>, body <code>((storage-class-data-&gt;body <var>storage-class</var>) <var>data</var>)</code>, with domain <code>(make-interval (vector <var>N</var>))</code>, where <code><var>N</var></code> is the greatest number of elements one can fit into <code><var>data</var></code>, and indexer <code>(lambda (i) i)</code>.</p>
+    <p>It is an error if the arguments do not satisfy these conditions.</p>
+    <p><b>Example: </b>In the reference implementation, if you want to construct a $3\times3$ array with storage class <code>u1-storage-class</code> from a length-one <code>u16vector</code> named <code><var>board</var></code> then one could write</p>
+    <pre><code>(let* ((board (u16vector #b111100110111))
+       (A (specialized-array-reshape
+           (array-extract
+            (make-specialized-array-from-data board u1-storage-class)
+            (make-interval '#(9)))
+           (make-interval '#(3 3))))
+       (B (list-&gt;array '(1 1 1
+                         0 1 1
+                         0 0 1)
+                       (make-interval '#(3 3))
+                       u1-storage-class)))
+  (define (pad n s)
+    (string-append (make-string (- n (string-length s)) #\0) s))
+  
+  (for-each display (list &quot;(array-every = A B) =&gt; &quot; (array-every = A B) #\newline))
+  (for-each display (list &quot;(array-body A) =&gt; &quot; (array-body A) #\newline))
+  (for-each display (list &quot;(array-body B) =&gt; &quot; (array-body B) #\newline))
+  (for-each display (list &quot;(pad 16 (number-&gt;string (u16vector-ref (vector-ref (array-body A) 1) 0) 2)) =&gt; &quot; #\newline
+                          (pad 16 (number-&gt;string (u16vector-ref (vector-ref (array-body A) 1) 0) 2)) #\newline))
+  (for-each display (list &quot;(pad 16 (number-&gt;string (u16vector-ref (vector-ref (array-body B) 1) 0) 2)) =&gt; &quot; #\newline
+                          (pad 16 (number-&gt;string (u16vector-ref (vector-ref (array-body B) 1) 0) 2)) #\newline)))</code></pre>
+    <p>prints</p>
+    <pre>(array-every = A B) =&gt; #t
+(array-body A) =&gt; #(16 #u16(3895))
+(array-body B) =&gt; #(9 #u16(311))
+(pad 16 (number-&gt;string (u16vector-ref (vector-ref (array-body A) 1) 0) 2)) =&gt; 
+0000111100110111
+(pad 16 (number-&gt;string (u16vector-ref (vector-ref (array-body B) 1) 0) 2)) =&gt; 
+0000000100110111</pre>
+    <p>The 9 low-order bits of board represent the entries of the array <code>A</code>, ignoring higher order bits, and you can see the bit order that is used to represent a <code>u1-storage-class-body</code>.</p>
     <p><b>Procedure: </b><code><a id="specialized-array?">specialized-array?</a> <var>obj</var></code></p>
     <p>Returns <code>#t</code> if <code><var>obj</var></code> is a specialized-array, and <code>#f</code> otherwise. A specialized-array is an array.</p>
     <p><b>Procedure: </b><code><a id="array-storage-class">array-storage-class</a> <var>array</var></code></p>

--- a/srfi-231.html
+++ b/srfi-231.html
@@ -45,17 +45,18 @@
       <li>If the first argument to <code>array-copy</code> is a specialized array, then omitted arguments are taken from the argument array and do not default to <code>generic-storage-class</code>, <code>(specialized-array-default-mutable?)</code>, and <code>(specialized-array-default-safe?)</code>.  Thus, by default, <code>array-copy</code> makes a true copy of a specialized array.</li>
       <li>Procedures that generate useful permutations have been added: <code>index-rotate</code>, <code>index-first</code>, and <code>index-last</code>.</li>
       <li><code>interval-rotate</code> and <code>array-rotate</code> have been removed; use <code>(array-permute A (index-rotate (array-dimension A) k))</code> instead of <code>(array-rotate A k)</code>.</li>
-      <li>Introduced new routines <code>storage-class-data?</code>, <code>storage-class-data-&gt;body</code>, <code>make-specialized-array-from-data</code>, <code>array-inner-product</code>, <code>array-stack</code>, and <code>array-append</code>.</li>
+      <li>Introduced new routines <code>storage-class-data?</code>, <code>storage-class-data-&gt;body</code>, <code>make-specialized-array-from-data</code>, <code>list*-&gt;array</code>, <code>vector*-&gt;array</code>, <code>array-inner-product</code>, <code>array-stack</code>, and <code>array-append</code>.</li>
       <li>A new set of &quot;Introductory remarks&quot; surveys some of the more important procedures in this SRFI.</li>
     </ul>
     <h2>Overview</h2>
     <h3>Introductory remarks</h3>
     <p>The next few sections talk perhaps too much about the mathematical ideas that underpin many of the procedures in this SRFI, so I discuss here some of the procedures and compare them to operations on spreadsheets,  matrices, and imaging.</p>
-    <p>There are two procedures that simply create new arrays, and one procedure that converts a list to an array:</p>
+    <p>There are two procedures that simply create new arrays, one procedure that converts a list to an array, and procedures that convert nested lists and nested vectors to arrays:</p>
     <ul>
       <li><a href="#make-array"><code>make-array</code></a>: Takes as arguments a specification of the valid indices $i\ j\ k$ etc. of the array, together with a Scheme procedure, which, when presented with indices in the valid range, computes the array element.   The elements of the array are not precomputed and stored somewhere, the specified procedure is recalculated each time that element is needed.  A procedure that modifies which element is returned at a given set of indices is allowed as a third argument.  See the sparse matrix example below to see how this is useful.  We call the result a <i>generalized array</i>.</li>
       <li><a href="#make-specialized-array"><code>make-specialized-array</code></a>: Takes as an argument a specification of a valid range of indices and reserves a block of memory in which to store elements of the matrix; optionally,  one can restrict which objects can be stored as elements in the array or generate code to precheck that all the indices are in range on each access, and to precheck that values stored as array elements actually comply with any given restrictions. Elements are stored in row-major order, as in C.  We call the result a <i>specialized array</i>.</li>
       <li><a href="#list-rarrow-array"><code>list-&gt;array</code></a>: Takes as arguments a list and a specification of valid indices, returns a specialized array.</li>
+      <li><a href="#list*-rarrow-array"><code>list*-&gt;array</code></a> and <a href="#vector*-rarrow-array"><code>vector*-&gt;array</code></a>: Convert nested lists and nested vectors, respectively, to arrays.</li>
     </ul>
     <p>In the next group of procedures, the new and old arrays share elements, so modifications to one affects the others.  Also, none of these procedures move any data: for specialized arrays they just change how the data are indexed, while for generalized arrays they manipulate the arguments of the getter and setter.  For specialized arrays, these procedures can be combined in any way without increasing unreasonably the number of operations required to access an array element. The procedures that build a new array (<code>array-curry</code> and <code>array-tile</code>) return a <i>generalized array</i>.</p>
     <ul>
@@ -235,6 +236,8 @@
         <a href="#array-every">array-every</a>,
         <a href="#array-rarrow-list">array-&gt;list</a>,
         <a href="#list-rarrow-array">list-&gt;array</a>,
+        <a href="#list*-rarrow-array">list*-&gt;array</a>,
+        <a href="#vector*-rarrow-array">vector*-&gt;array</a>,
         <a href="#array-assign!">array-assign!</a>,
         <a href="#array-append">array-append</a>,
         <a href="#array-stack">array-stack</a>,
@@ -1214,6 +1217,56 @@ indexer:       (lambda multi-index
     <p>Assumes that <code><var>l</var></code> is an list, <code><var>domain</var></code> is an interval with volume the same as the length of <code><var>l</var></code>,  <code><var>result-storage-class</var></code> is a storage class that can manipulate all the elements of <code><var>l</var></code>, and <code><var>mutable?</var></code> and <code><var>safe?</var></code> are booleans.</p>
     <p>Returns a specialized array with domain <code><var>domain</var></code> whose elements are the elements of the list <code><var>l</var></code> stored in lexicographical order.  The result is mutable or safe depending on the values of <code><var>mutable?</var></code> and <code><var>safe?</var></code>.</p>
     <p>It is an error if the arguments do not satisfy these assumptions, or if any element of  <code><var>l</var></code> cannot be stored in the body of <code><var>result-storage-class</var></code>, and this last error shall be detected and raised.</p>
+    <p><b>Procedure: </b><code><a id="list*-rarrow-array">list*-&gt;array</a> <var>nested-list</var> <var>d</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>mutable?</var> (specialized-array-default-mutable?) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
+    <p>Assumes that <code><var>d</var></code> is a positive exact integer and, if given, <code><var>storage-class</var></code> is a storage class and <code><var>mutable?</var></code> and <code><var>safe?</var></code> are booleans.</p>
+    <p>This routine builds an array of dimension <code><var>d</var></code>, storage class <code><var>storage-class</var></code>, mutability <code><var>mutable?</var></code>, and safety <code><var>safe?</var></code> from <code><var>nested-list</var></code>.  It is assumed that following predicate does not return <code>#f</code> when passed <code><var>nested-list</var></code> and <code><var>d</var></code> as arguments:</p>
+    <pre><code>(define (check-nested-list nested-list d)
+  (and (list? nested-list)
+       (let ((len (length nested-list)))
+         (and (positive? len)
+              (if (eqv? d 1)
+                  (list len)
+                  (let* ((sublists
+                          (map (lambda (l)
+                                 (check-nested-list l (fx- d 1)))
+                               nested-list))
+                         (first
+                          (car sublists)))
+                    (and (pair? first)
+                         (every (lambda (l)
+                                  (equal? first l))
+                                (cdr sublists))
+                         (cons len first))))))))</code></pre>
+    <p>In this case, <code>list*-&gt;array</code> returns an array with domain <code>(make-interval (list-&gt;vector (check-nested-list <var>nested-list d</var>)))</code>.  If we denote the getter of the result by <code>A_</code>, then </p>
+    <pre><code>(A_ i_0 ... i_d-2 i_d-1)
+=&gt; (list-ref (list-ref (... (list-ref nested-list i_0) ...) i_d-2) i_d-1)</code></pre>
+    <p>and we assume that this value can be manipulated by <code><var>storage-class</var></code>.</p>
+    <p>It is an error if the arguments do not satisfy these assumptions.</p>
+    <p><b>Procedure: </b><code><a id="vector*-rarrow-array">vector*-&gt;array</a> <var>nested-vector</var> <var>d</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>mutable?</var> (specialized-array-default-mutable?) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
+    <p>Assumes that <code><var>d</var></code> is a positive exact integer and, if given, <code><var>storage-class</var></code> is a storage class and <code><var>mutable?</var></code> and <code><var>safe?</var></code> are booleans.</p>
+    <p>This routine builds an array of dimension <code><var>d</var></code>, storage class <code><var>storage-class</var></code>, mutability <code><var>mutable?</var></code>, and safety <code><var>safe?</var></code> from <code><var>nested-vector</var></code>.  It is assumed that following predicate does not return <code>#f</code> when passed <code><var>nested-vector</var></code> and <code><var>d</var></code> as arguments:</p>
+    <pre><code>(define (check-nested-vector nested-vector d)
+  (and (vector? nested-vector)
+       (let ((len (vector-length nested-vector)))
+         (and (positive? len)
+              (if (eqv? d 1)
+                  (list len)
+                  (let* ((sublists
+                          (map (lambda (l)
+                                 (check-nested-vector l (fx- d 1)))
+                               (vector-&gt;list nested-vector)))
+                         (first
+                          (car sublists)))
+                    (and (pair? first)
+                         (every (lambda (l)
+                                  (equal? first l))
+                                (cdr sublists))
+                         (cons len first))))))))</code></pre>
+    <p>In this case, <code>vector*-&gt;array</code> returns an array with domain <code>(make-interval (list-&gt;vector (check-nested-vector <var>nested-vector d</var>)))</code>.  If we denote the getter of the result by <code>A_</code>, then </p>
+    <pre><code>(A_ i_0 ... i_d-2 i_d-1)
+=&gt; (vector-ref (vector-ref (... (vector-ref nested-vector i_0) ...) i_d-2) i_d-1)</code></pre>
+    <p>and we assume that this value can be manipulated by <code><var>storage-class</var></code>.</p>
+    <p>It is an error if the arguments do not satisfy these assumptions.</p>
     <p><b>Procedure: </b><code><a id="array-assign!">array-assign!</a> <var>destination</var> <var>source</var></code></p>
     <p>Assumes that <code><var>destination</var></code> is a mutable array and <code><var>source</var></code> is an array with the same domain, and that the elements of <code><var>source</var></code> can be stored into <code><var>destination</var></code>.</p>
     <p>Evaluates <code>(array-getter <var>source</var>)</code> on the multi-indices in <code>(array-domain <var>source</var>)</code> in lexicographical order, and assigns each value to the multi-index in <code><var>destination</var></code> in the same lexicographical order.</p>

--- a/srfi-231.html
+++ b/srfi-231.html
@@ -21,6 +21,7 @@
       <li>Received: 2022-01-05</li>
       <li>60-day deadline: 2022-03-08</li>
       <li>Draft #1 published: 2022-01-07</li>
+      <li>Draft #2 published: 2022-01-20</li>
       <li>Bradley Lucier's <a href="https://github.com/gambiteer/srfi-231">personal Git repo for this SRFI</a> for reference while the SRFI is in <em>draft</em> status.</li>
     </ul>
     <h2>Abstract</h2>

--- a/srfi-231.scm
+++ b/srfi-231.scm
@@ -285,14 +285,7 @@ they may have hash tables or databases behind an implementation, one may read th
         (<h2> "Issues")
         (<ul>
          (<li> "Should eager comprehensions in the style of "(<a> href: "https://srfi.schemers.org/srfi-42/" "SRFI 42")" be added to this SRFI, as "(<a> href: "https://srfi-email.schemers.org/srfi-179/msg/18428002/" "suggested")" by Jens Axel Søgaard?  My opinion is yes, but I would need major help in designing and implementing such things.")
-         (<li> "Should "(<a> href: "#specialized-array-default-mutable?" (<code>'specialized-array-default-mutable?))" and "(<a> href: "#specialized-array-default-safe?" (<code>'specialized-array-default-safe?))" be "(<a> href: "https://srfi.schemers.org/srfi-39/" "SRFI 39")" parameters or "(<a> href: "https://small.r7rs.org/attachment/r7rs.pdf" "R7RS")" parameters? Or would some other way of specifying, and changing, the default safety and mutability of specialized arrays be better?")
          (<li> "Could "(<a> href: "#array-elements-in-order?" (<code> "array-elements-in-order?"))" have a better name or description?")
-         (<li> "The naming convention is not entirely uniform; most array functions begin with "(<code>'array-)" but there are also "
-               (<ul>
-                (<li> (<code>'make-array)", "(<code>'make-interval)", "(<code>'make-storage-class)", and "(<code>'make-specialized-array))
-                (<li> (<code>'mutable-array?)))
-               "All other operations begin with the name of the objects that they take as arguments, or that they return.  The question is whether we should change these few names.")
-                
          )
 
 
@@ -309,9 +302,6 @@ they may have hash tables or databases behind an implementation, one may read th
          (<li> (<b> "Choice of procedures on intervals. ")"The choice of procedures for both arrays and intervals was motivated almost solely by what I needed for arrays.")
          (<li> (<b> "No empty intervals. ")"This SRFI considers arrays over only nonempty intervals of positive dimension.  The author of this proposal acknowledges that other languages and array systems allow either zero-dimensional intervals or empty intervals of positive dimension, but prefers to leave such empty intervals as possibly compatible extensions to the current proposal.")
          (<li> (<b> "Multi-valued arrays. ")"While this SRFI restricts attention to single-valued arrays, wherein the getter of each array returns a single value, allowing multi-valued immutable arrays would be a compatible extension of this SRFI.")
-         (<li> (<b> "No low-level specialized array constructor. ")
-               "While the author of the SRFI uses mainly "(<code>"(make-array ...)")", "(<code>'array-map)", and "(<code>'array-copy)" to construct arrays, and while there are several other ways to construct arrays, there is no really low-level interface given for constructing specialized arrays (where one specifies a body, an indexer, etc.).  It was felt that certain difficulties, some surmountable (such as checking that a given body is compatible with a given storage class) and some not (such as checking that an indexer is indeed affine), made a low-level interface less useful.  At the same time, the simple "(<code>"(make-array ...)")" mechanism is so general, allowing one to specify getters and setters as general procedures, as to cover nearly all needs.")
-
          )
         (<h2> "Specification")
         (let ((END ",\n"))

--- a/srfi-231.scm
+++ b/srfi-231.scm
@@ -74,6 +74,7 @@ MathJax.Hub.Config({
          (<li> "Received: 2022-01-05")
          (<li> "60-day deadline: 2022-03-08")
          (<li> "Draft #1 published: 2022-01-07")
+         (<li> "Draft #2 published: 2022-01-20")
          (<li> "Bradley Lucier's "(<a> href: "https://github.com/gambiteer/srfi-231" "personal Git repo for this SRFI")" for reference while the SRFI is in "(<em>'draft)" status.")
          )
 

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -662,20 +662,20 @@ OTHER DEALINGS IN THE SOFTWARE.
 (pp "storage-class tests")
 
 (define storage-class-names
-  (list (list   u1-storage-class   'u1-storage-class 'u16vector)
-        (list   u8-storage-class   'u8-storage-class  'u8vector)
-        (list  u16-storage-class  'u16-storage-class 'u16vector)
-        (list  u32-storage-class  'u32-storage-class 'u32vector)
-        (list  u64-storage-class  'u64-storage-class 'u64vector)
-        (list   s8-storage-class   's8-storage-class  's8vector)
-        (list  s16-storage-class  's16-storage-class 's16vector)
-        (list  s32-storage-class  's32-storage-class 's32vector)
-        (list  s64-storage-class  's64-storage-class 's64vector)
-        (list  f32-storage-class  'f32-storage-class 'f32vector)
-        (list  f64-storage-class  'f64-storage-class 'f64vector)
-        (list  c64-storage-class  'c64-storage-class 'f32vector)
-        (list c128-storage-class 'c128-storage-class 'f64vector)
-         ))
+  (list (list   u1-storage-class   'u1-storage-class 'u16vector make-u16vector)
+        (list   u8-storage-class   'u8-storage-class  'u8vector  make-u8vector)
+        (list  u16-storage-class  'u16-storage-class 'u16vector make-u16vector)
+        (list  u32-storage-class  'u32-storage-class 'u32vector make-u32vector)
+        (list  u64-storage-class  'u64-storage-class 'u64vector make-u64vector)
+        (list   s8-storage-class   's8-storage-class  's8vector  make-s8vector)
+        (list  s16-storage-class  's16-storage-class 's16vector make-s16vector)
+        (list  s32-storage-class  's32-storage-class 's32vector make-s32vector)
+        (list  s64-storage-class  's64-storage-class 's64vector make-s64vector)
+        (list  f32-storage-class  'f32-storage-class 'f32vector make-f32vector)
+        (list  f64-storage-class  'f64-storage-class 'f64vector make-f64vector)
+        (list  c64-storage-class  'c64-storage-class 'f32vector make-f32vector)
+        (list c128-storage-class 'c128-storage-class 'f64vector make-f64vector)
+        ))
 
 (define uniform-storage-classes
   (list u8-storage-class u16-storage-class u32-storage-class u64-storage-class
@@ -694,13 +694,15 @@ OTHER DEALINGS IN THE SOFTWARE.
 (test ((storage-class-data? u1-storage-class) (u16vector 0))
       #t)
 
-(for-each (lambda (class-name-data)
+(for-each (lambda (class-name-data-maker)
             (let* ((class
-                    (car class-name-data))
+                    (car class-name-data-maker))
                    (name
-                    (cadr class-name-data))
+                    (cadr class-name-data-maker))
                    (data
-                    (caddr class-name-data))
+                    (caddr class-name-data-maker))
+                   (maker
+                    (cadddr class-name-data-maker))
                    (message
                     (string-append "Expecting a nonempty "
                                    (symbol->string data)
@@ -711,6 +713,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                                    (symbol->string name)
                                    "): ")))
               (test ((storage-class-data->body class) 'a)
+                    message)
+              (test ((storage-class-data->body class) (maker 0))
                     message)))
           storage-class-names)
 
@@ -989,8 +993,7 @@ OTHER DEALINGS IN THE SOFTWARE.
   (for-each display (list "(pad 16 (number->string (u16vector-ref (vector-ref (array-body A) 1) 0) 2)) => " #\newline
                           (pad 16 (number->string (u16vector-ref (vector-ref (array-body A) 1) 0) 2)) #\newline))
   (for-each display (list "(pad 16 (number->string (u16vector-ref (vector-ref (array-body B) 1) 0) 2)) => " #\newline
-                           (pad 16 (number->string (u16vector-ref (vector-ref (array-body B) 1) 0) 2)) #\newline))
-  )
+                           (pad 16 (number->string (u16vector-ref (vector-ref (array-body B) 1) 0) 2)) #\newline)))
 
 
 


### PR DESCRIPTION
Major changes:

1.  Define, document, and test data? and data->body slots in storage-class structure.

2.  Define those entries for predefined storage classes.

3.  Define, document, and test make-specialized-array-from-data.

4.  Define, document, and test list*->array and vector*-array.

See the individual commit messages for details.
