### PR TITLE
Change argument order for make-specialized-array

### DIFF
--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -763,108 +763,108 @@ OTHER DEALINGS IN THE SOFTWARE.
 ;;; (...(operator (operator (operator identity (f multi-index_1)) (f multi-index_2)) (f multi-index_3)) ...)
 ;;;
 ;;; where multi-index_1, multi-index_2, ... are the elements of interval in lexicographical order
-;;; This version assumes, and may use, that f is thread-safe and that operator is associative.
-;;; The order of application of f and operator is not specified.
 
 (define (%%interval-foldl f operator identity interval)
-  (case (%%interval-dimension interval)
-    ((0) (operator identity (f)))
-    ((1) (let ((lower-i (%%interval-lower-bound interval 0))
-               (upper-i (%%interval-upper-bound interval 0)))
-           (let i-loop ((i lower-i) (result identity))
-             (if (= i upper-i)
-                 result
-                 (i-loop (+ i 1) (operator result (f i)))))))
-    ((2) (let ((lower-i (%%interval-lower-bound interval 0))
-               (lower-j (%%interval-lower-bound interval 1))
-               (upper-i (%%interval-upper-bound interval 0))
-               (upper-j (%%interval-upper-bound interval 1)))
-           (let i-loop ((i lower-i) (result identity))
-             (if (= i upper-i)
-                 result
-                 (let j-loop ((j lower-j) (result result))
-                   (if (= j upper-j)
-                       (i-loop (+ i 1) result)
-                       (j-loop (+ j 1) (operator result (f i j)))))))))
-    ((3) (let ((lower-i (%%interval-lower-bound interval 0))
-               (lower-j (%%interval-lower-bound interval 1))
-               (lower-k (%%interval-lower-bound interval 2))
-               (upper-i (%%interval-upper-bound interval 0))
-               (upper-j (%%interval-upper-bound interval 1))
-               (upper-k (%%interval-upper-bound interval 2)))
-           (let i-loop ((i lower-i) (result identity))
-             (if (= i upper-i)
-                 result
-                 (let j-loop ((j lower-j) (result result))
-                   (if (= j upper-j)
-                       (i-loop (+ i 1) result)
-                       (let k-loop ((k lower-k) (result result))
-                         (if (= k upper-k)
-                             (j-loop (+ j 1) result)
-                             (k-loop (+ k 1) (operator result (f i j k)))))))))))
-    ((4) (let ((lower-i (%%interval-lower-bound interval 0))
-               (lower-j (%%interval-lower-bound interval 1))
-               (lower-k (%%interval-lower-bound interval 2))
-               (lower-l (%%interval-lower-bound interval 3))
-               (upper-i (%%interval-upper-bound interval 0))
-               (upper-j (%%interval-upper-bound interval 1))
-               (upper-k (%%interval-upper-bound interval 2))
-               (upper-l (%%interval-upper-bound interval 3)))
-           (let i-loop ((i lower-i) (result identity))
-             (if (= i upper-i)
-                 result
-                 (let j-loop ((j lower-j) (result result))
-                   (if (= j upper-j)
-                       (i-loop (+ i 1) result)
-                       (let k-loop ((k lower-k) (result result))
-                         (if (= k upper-k)
-                             (j-loop (+ j 1) result)
-                             (let l-loop ((l lower-l) (result result))
-                               (if (= l upper-l)
-                                   (k-loop (+ k 1) result)
-                                   (l-loop (+ l 1) (operator result (f i j k l)))))))))))))
-    (else
-     (let* ((lower-bounds (%%interval-lower-bounds->list interval))
-            (upper-bounds (%%interval-upper-bounds->list interval))
-            (arg          (map values lower-bounds)))                ; copy lower-bounds
-
-       ;; I'm not particularly happy with set! here because f or operator might capture
-       ;; the continuation and then funny things might pursue ...
-       ;; But it seems that the only way to have this work efficiently without the set~
-       ;; is to have arrays with fortran-style numbering.
-       ;; blah
-
-       (define (iterate lower-bounds-tail
-                        upper-bounds-tail
-                        arg-tail
-                        result)
-         (let ((lower-bound (car lower-bounds-tail))
-               (upper-bound (car upper-bounds-tail)))
-           (if (null? (cdr arg-tail))
-               (let loop ((i lower-bound)
-                          (result result))
-                 (if (= i upper-bound)
+  (if (%%interval-empty? interval) ;; handle (make-interval '#(10000000 10000000 0)) efficiently
+      identity
+      (case (%%interval-dimension interval)
+        ((0) (operator identity (f)))
+        ((1) (let ((lower-i (%%interval-lower-bound interval 0))
+                   (upper-i (%%interval-upper-bound interval 0)))
+               (let i-loop ((i lower-i) (result identity))
+                 (if (= i upper-i)
                      result
-                     (begin
-                       (set-car! arg-tail i)
-                       (loop (+ i 1)
-                             (operator result (apply f arg))))))
-               (let loop ((i lower-bound)
-                          (result result))
-                 (if (= i upper-bound)
+                     (i-loop (+ i 1) (operator result (f i)))))))
+        ((2) (let ((lower-i (%%interval-lower-bound interval 0))
+                   (lower-j (%%interval-lower-bound interval 1))
+                   (upper-i (%%interval-upper-bound interval 0))
+                   (upper-j (%%interval-upper-bound interval 1)))
+               (let i-loop ((i lower-i) (result identity))
+                 (if (= i upper-i)
                      result
-                     (begin
-                       (set-car! arg-tail i)
-                       (loop (+ i 1)
-                             (iterate (cdr lower-bounds-tail)
-                                      (cdr upper-bounds-tail)
-                                      (cdr arg-tail)
-                                      result))))))))
+                     (let j-loop ((j lower-j) (result result))
+                       (if (= j upper-j)
+                           (i-loop (+ i 1) result)
+                           (j-loop (+ j 1) (operator result (f i j)))))))))
+        ((3) (let ((lower-i (%%interval-lower-bound interval 0))
+                   (lower-j (%%interval-lower-bound interval 1))
+                   (lower-k (%%interval-lower-bound interval 2))
+                   (upper-i (%%interval-upper-bound interval 0))
+                   (upper-j (%%interval-upper-bound interval 1))
+                   (upper-k (%%interval-upper-bound interval 2)))
+               (let i-loop ((i lower-i) (result identity))
+                 (if (= i upper-i)
+                     result
+                     (let j-loop ((j lower-j) (result result))
+                       (if (= j upper-j)
+                           (i-loop (+ i 1) result)
+                           (let k-loop ((k lower-k) (result result))
+                             (if (= k upper-k)
+                                 (j-loop (+ j 1) result)
+                                 (k-loop (+ k 1) (operator result (f i j k)))))))))))
+        ((4) (let ((lower-i (%%interval-lower-bound interval 0))
+                   (lower-j (%%interval-lower-bound interval 1))
+                   (lower-k (%%interval-lower-bound interval 2))
+                   (lower-l (%%interval-lower-bound interval 3))
+                   (upper-i (%%interval-upper-bound interval 0))
+                   (upper-j (%%interval-upper-bound interval 1))
+                   (upper-k (%%interval-upper-bound interval 2))
+                   (upper-l (%%interval-upper-bound interval 3)))
+               (let i-loop ((i lower-i) (result identity))
+                 (if (= i upper-i)
+                     result
+                     (let j-loop ((j lower-j) (result result))
+                       (if (= j upper-j)
+                           (i-loop (+ i 1) result)
+                           (let k-loop ((k lower-k) (result result))
+                             (if (= k upper-k)
+                                 (j-loop (+ j 1) result)
+                                 (let l-loop ((l lower-l) (result result))
+                                   (if (= l upper-l)
+                                       (k-loop (+ k 1) result)
+                                       (l-loop (+ l 1) (operator result (f i j k l)))))))))))))
+        (else
+         (let* ((lower-bounds (%%interval-lower-bounds->list interval))
+                (upper-bounds (%%interval-upper-bounds->list interval))
+                (arg          (map values lower-bounds)))                ; copy lower-bounds
 
-       (iterate lower-bounds
-                upper-bounds
-                arg
-                identity)))))
+           ;; I'm not particularly happy with set! here because f or operator might capture
+           ;; the continuation and then funny things might pursue ...
+           ;; But it seems that the only way to have this work efficiently without the set~
+           ;; is to have arrays with fortran-style numbering.
+           ;; blah
+
+           (define (iterate lower-bounds-tail
+                            upper-bounds-tail
+                            arg-tail
+                            result)
+             (let ((lower-bound (car lower-bounds-tail))
+                   (upper-bound (car upper-bounds-tail)))
+               (if (null? (cdr arg-tail))
+                   (let loop ((i lower-bound)
+                              (result result))
+                     (if (= i upper-bound)
+                         result
+                         (begin
+                           (set-car! arg-tail i)
+                           (loop (+ i 1)
+                                 (operator result (apply f arg))))))
+                   (let loop ((i lower-bound)
+                              (result result))
+                     (if (= i upper-bound)
+                         result
+                         (begin
+                           (set-car! arg-tail i)
+                           (loop (+ i 1)
+                                 (iterate (cdr lower-bounds-tail)
+                                          (cdr upper-bounds-tail)
+                                          (cdr arg-tail)
+                                          result))))))))
+
+           (iterate lower-bounds
+                    upper-bounds
+                    arg
+                    identity))))))
 
 ;; We'll use the same basic container for all types of arrays.
 

--- a/srfi-231.html
+++ b/srfi-231.html
@@ -56,7 +56,7 @@
       <li><code>interval-rotate</code> and <code>array-rotate</code> have been removed; use <code>(array-permute A (index-rotate (array-dimension A) k))</code> instead of <code>(array-rotate A k)</code>.</li>
       <li><code>array-tile</code> is now more flexible in how you can decompose an array.</li>
       <li><code>char-storage-class</code> is provided.</li>
-      <li>Introduced new procedures <a href="#interval-width"><code>interval-width</code></a>, <a href="#interval-widths"><code>interval-widths</code></a>, <a href="#interval-empty?"><code>interval-empty?</code></a>, <a href="#storage-class-data?"><code>storage-class-data?</code></a>, <a href="#storage-class-data-rarrow-body"><code>storage-class-data-&gt;body</code></a>, <a href="#array-empty?"><code>array-empty</code></a>, <a href="#make-specialized-array-from-data"><code>make-specialized-array-from-data</code></a>, <a href="#vector-rarrow-array"><code>vector-&gt;array</code></a>, <a href="#array-rarrow-vector"><code>array-&gt;vector</code></a>, <a href="#list*-rarrow-array"><code>list*-&gt;array</code></a>, <a href="#array-rarrow-list*"><code>array-&gt;list*</code></a>, <a href="#vector*-rarrow-array"><code>vector*-&gt;array</code></a>, <a href="#array-rarrow-vector*"><code>array-&gt;vector*</code></a>, <a href="#array-inner-product"><code>array-inner-product</code></a>, <a href="#array-stack"><code>array-stack</code></a>, <a href="#array-append"><code>array-append</code></a>, and <a href="#array-block"><code>array-block</code></a>.</li>
+      <li>Introduced new procedures <a href="#interval-width"><code>interval-width</code></a>, <a href="#interval-widths"><code>interval-widths</code></a>, <a href="#interval-empty?"><code>interval-empty?</code></a>, <a href="#storage-class-data?"><code>storage-class-data?</code></a>, <a href="#storage-class-data-rarrow-body"><code>storage-class-data-&gt;body</code></a>, <a href="#array-empty?"><code>array-empty?</code></a>, <a href="#make-specialized-array-from-data"><code>make-specialized-array-from-data</code></a>, <a href="#vector-rarrow-array"><code>vector-&gt;array</code></a>, <a href="#array-rarrow-vector"><code>array-&gt;vector</code></a>, <a href="#list*-rarrow-array"><code>list*-&gt;array</code></a>, <a href="#array-rarrow-list*"><code>array-&gt;list*</code></a>, <a href="#vector*-rarrow-array"><code>vector*-&gt;array</code></a>, <a href="#array-rarrow-vector*"><code>array-&gt;vector*</code></a>, <a href="#array-inner-product"><code>array-inner-product</code></a>, <a href="#array-stack"><code>array-stack</code></a>, <a href="#array-append"><code>array-append</code></a>, and <a href="#array-block"><code>array-block</code></a>.</li>
       <li>A new set of &quot;Introductory remarks&quot; surveys some of the more important procedures in this SRFI.</li>
     </ul>
     <h2>Overview</h2>
@@ -229,7 +229,7 @@
         <a href="#array-dimension">array-dimension</a>,
         <a href="#mutable-array?">mutable-array?</a>,
         <a href="#array-setter">array-setter</a>,
-        <a href="#array-empty?">array-empty</a>,
+        <a href="#array-empty?">array-empty?</a>,
         <a href="#make-specialized-array">make-specialized-array</a>,
         <a href="#make-specialized-array-from-data">make-specialized-array-from-data</a>,
         <a href="#specialized-array?">specialized-array?</a>,
@@ -644,8 +644,8 @@
 (a_ 0 0) =&gt; 1.</code></pre>
     <p><b>Example: </b> If an array <code>A</code> is empty, e.g., <code>(make-array (make-interval '#(0 0)) getter setter)</code>, then it is an error to call <code>getter</code> or <code>setter</code>.  Still, such arrays can usefully exist to simplify limit cases of some algorithms.</p>
     <p><b>Example: </b><code>(define a (make-array (make-interval '#()) (lambda () 42)))</code> makes an array with a zero-dimensional domain whose getter takes no arguments and always returns 42.</p>
-    <p><b>Example: </b>We can have the following interactive session, which builds a zero-dimensional mutable array: </p><pre>
-    <code>&gt; (define a
+    <p><b>Example: </b>We can have the following interactive session, which builds a zero-dimensional mutable array: </p>
+    <pre><code>&gt; (define a
     (let ((contents (box 42)))
       (make-array
        (make-interval '#())
@@ -1593,7 +1593,7 @@ indexer:       (lambda multi-index
  ((3 0) (3 1) (3 2) (3 3) (3 4) (3 5)))</code></pre>
     <p>Because this SRFI supports empty arrays, the same code works when $k=0$ (when the second extracted array is empty) or $k=m-1$ (when the third extracted array is empty).</p>
     <p><b>Procedure: </b><code><a id="array-block">array-block</a> <var>A</var> [ <var>storage-class</var> [ <var>mutable?</var> [ <var>safe?</var> ] ] ]</code></p>
-    <p>This procedure is an inverse to <code>array-tile</code>.  It assumes that <code><var>A</var></code> is nonempty array of arrays, all of which have the same dimension as <code><var>A</var></code> itself. It also assumes that, if given, <code><var>storage-class</var></code> is a storage class and <code><var>mutable?</var></code> and <code><var>safe?</var></code> are booleans.</p>
+    <p>This procedure is an inverse to <code>array-tile</code>.  It assumes that <code><var>A</var></code> is a nonempty array of arrays, all of which have the same dimension as <code><var>A</var></code> itself. It also assumes that, if given, <code><var>storage-class</var></code> is a storage class and <code><var>mutable?</var></code> and <code><var>safe?</var></code> are booleans.</p>
     <p>While ignoring the lower and upper bounds of the element arrays, it assumes that those element arrays have widths (as defined by <code>interval-widths</code>) that allow them to be packed together, in the configuration given by their indices in <code><var>A</var></code>.  We can always do this when <code>(array-dimension <var>A</var>)</code> is 1.  Otherwise, assuming that the lower bounds of <code><var>A</var></code> are zero, we require: </p>
     <pre><code>(every
  (lambda (k)                                        ;; for each coordinate direction

--- a/srfi-231.html
+++ b/srfi-231.html
@@ -691,7 +691,7 @@
       if <code><var>array</var></code> is not a mutable array.</p>
     <p><b>Procedure: </b><code><a id="array-empty?">array-empty?</a> <var>a</var></code></p>
     <p>Assumes <code><var>a</var></code> is an array, and returns <code>(interval-empty? (array-domain <var>a</var>))</code>.  It is an error if the argument is not an array.</p>
-    <p><b>Procedure: </b><code><a id="make-specialized-array">make-specialized-array</a> <var>interval</var> [ <var>initial-value</var> (storage-class-default  <var>storage-class</var> ) ] [ <var>storage-class</var> generic-storage-class ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
+    <p><b>Procedure: </b><code><a id="make-specialized-array">make-specialized-array</a> <var>interval</var> [ <var>storage-class</var> generic-storage-class ] [ <var>initial-value</var> (storage-class-default  <var>storage-class</var> ) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
     <p>Constructs a mutable specialized array from its arguments.</p>
     <p><code><var>interval</var></code> must be given an interval. If given, <code><var>storage-class</var></code> must be a storage class; if it is not given it defaults to <code>generic-storage-class</code>. If given, <code><var>initial-value</var></code> must be a value that can be manipulated by <code><var>storage-class</var></code>; if it is not given it defaults to <code>(storage-class-default <var>storage-class</var>)</code>. If given, <code><var>safe?</var></code> must be a boolean; if it is not given it defaults to the current value of <code>(specialized-array-default-safe?)</code>.</p>
     <p>The body of the result is constructed as </p>

--- a/srfi-231.scm
+++ b/srfi-231.scm
@@ -80,7 +80,7 @@ MathJax.Hub.Config({
          (<li> "Draft #5 published: 2022-03-16")
          (<li> "Draft #6 published: 2022-03-17")
          (<li> "Draft #7 published: 2022-04-25")
-         (<li> "Draft #8 published: 2022-04-25")
+         (<li> "Draft #8 published: 2022-05-23")
          (<li> "Bradley Lucier's "(<a> href: "https://github.com/gambiteer/srfi-231" "personal Git repo for this SRFI")" for reference while the SRFI is in "(<em>'draft)" status.")
          )
 
@@ -124,7 +124,7 @@ MathJax.Hub.Config({
                (<a> href: "#interval-empty?" (<code>'interval-empty?))", "
                (<a> href: "#storage-class-data?" (<code>'storage-class-data?))", "
                (<a> href: "#storage-class-data-rarrow-body" (<code>'storage-class-data->body))", "
-               (<a> href: "#array-empty?" (<code>'array-empty))", "
+               (<a> href: "#array-empty?" (<code>'array-empty?))", "
                (<a> href: "#make-specialized-array-from-data" (<code>'make-specialized-array-from-data))", "
                (<a> href: "#vector-rarrow-array" (<code>'vector->array))", "
                (<a> href: "#array-rarrow-vector" (<code>'array->vector))", "
@@ -414,7 +414,7 @@ they may have hash tables or databases behind an implementation, one may read th
                  (<a> href: "#array-dimension" "array-dimension")END
                  (<a> href: "#mutable-array?" "mutable-array?")END
                  (<a> href: "#array-setter" "array-setter")END
-                 (<a> href: "#array-empty?" "array-empty")END
+                 (<a> href: "#array-empty?" "array-empty?")END
                  (<a> href: "#make-specialized-array" "make-specialized-array")END
                  (<a> href: "#make-specialized-array-from-data" "make-specialized-array-from-data")END
                  (<a> href: "#specialized-array?" "specialized-array?")END
@@ -2123,7 +2123,7 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
 
 
 (format-lambda-list '(array-block A #\[ storage-class #\[ mutable? #\[ safe? #\] #\] #\]))
-(<p> "This procedure is an inverse to "(<code>'array-tile)".  It assumes that "(<code>(<var>'A))" is nonempty array of arrays, all of which have the same dimension as "(<code>(<var>'A))" itself. It also assumes that, if given, "(<code>(<var>'storage-class))" is a storage class and "(<code>(<var>'mutable?))" and "(<code>(<var>'safe?))" are booleans.")
+(<p> "This procedure is an inverse to "(<code>'array-tile)".  It assumes that "(<code>(<var>'A))" is a nonempty array of arrays, all of which have the same dimension as "(<code>(<var>'A))" itself. It also assumes that, if given, "(<code>(<var>'storage-class))" is a storage class and "(<code>(<var>'mutable?))" and "(<code>(<var>'safe?))" are booleans.")
 (<p> "While ignoring the lower and upper bounds of the element arrays, it assumes that those element arrays have widths (as defined by "(<code>'interval-widths)") that allow them to be packed together, in the configuration given by their indices in "(<code>(<var>'A))".  We can always do this when "(<code>"(array-dimension "(<var>'A)")")" is 1.  Otherwise, assuming that the lower bounds of "(<code>(<var>'A))" are zero, we require: ")
 (<pre>(<code>"(every
  (lambda (k)                                        ;; for each coordinate direction

--- a/srfi-231.scm
+++ b/srfi-231.scm
@@ -987,8 +987,8 @@ if "(<code>(<var> 'array))" is not a mutable array.")
 
 
 (format-lambda-list '(make-specialized-array interval
-                                             #\[ initial-value "(storage-class-default " storage-class")" #\]
                                              #\[ storage-class "generic-storage-class" #\]
+                                             #\[ initial-value "(storage-class-default " storage-class")" #\]
                                              #\[ safe? "(specialized-array-default-safe?)" #\]))
 (<p> "Constructs a mutable specialized array from its arguments.")
 (<p> (<code>(<var>'interval))" must be given an interval. If given, "(<code>(<var>'storage-class))" must be a storage class; if it is not given it defaults to "(<code>'generic-storage-class)". If given, "(<code>(<var>'initial-value))" must be a value that can be manipulated by "(<code>(<var>'storage-class))"; if it is not given it defaults to "(<code>"(storage-class-default "(<var>'storage-class)")")". If given, "(<code>(<var>'safe?))" must be a boolean; if it is not given it defaults to the current value of "(<code>"(specialized-array-default-safe?)")".")

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -1000,33 +1000,33 @@ OTHER DEALINGS IN THE SOFTWARE.
       "make-specialized-array: The first argument is not an interval: ")
 
 (test (make-specialized-array (make-interval '#(0) '#(10)) 'a 1)
-      "make-specialized-array: The third argument is not a storage-class: ")
+      "make-specialized-array: The second argument is not a storage-class: ")
 
-(test (make-specialized-array (make-interval '#(0) '#(10)) 'a u16-storage-class)
-      "make-specialized-array: The second argument cannot be manipulated by the third (a storage class): ")
+(test (make-specialized-array (make-interval '#(0) '#(10)) u16-storage-class 'a)
+      "make-specialized-array: The third argument cannot be manipulated by the second (a storage class): ")
 
 
-(test (make-specialized-array (make-interval '#(0) '#(10)) 'a generic-storage-class 'a)
+(test (make-specialized-array (make-interval '#(0) '#(10)) generic-storage-class 'a 'a)
       "make-specialized-array: The fourth argument is not a boolean: ")
 
 ;;; let's test a few more
 
-(test (array-every (lambda (x) (eqv? x 42)) (make-specialized-array (make-interval '#(10)) 42 u8-storage-class))
+(test (array-every (lambda (x) (eqv? x 42)) (make-specialized-array (make-interval '#(10)) u8-storage-class 42))
       #t)
 
-(test (array-safe? (make-specialized-array (make-interval '#(10)) 42 u8-storage-class))
+(test (array-safe? (make-specialized-array (make-interval '#(10)) u8-storage-class 42))
       (specialized-array-default-safe?))
 
-(test (parameterize ((specialized-array-default-safe? #t)) (array-safe? (make-specialized-array (make-interval '#(10)) 42 u8-storage-class)))
+(test (parameterize ((specialized-array-default-safe? #t)) (array-safe? (make-specialized-array (make-interval '#(10)) u8-storage-class 42)))
       #t)
 
-(test (parameterize ((specialized-array-default-safe? #f)) (array-safe? (make-specialized-array (make-interval '#(10)) 42 u8-storage-class)))
+(test (parameterize ((specialized-array-default-safe? #f)) (array-safe? (make-specialized-array (make-interval '#(10)) u8-storage-class 42)))
       #f)
 
-(test (array-safe? (make-specialized-array (make-interval '#(10)) 42 u8-storage-class  #t))
+(test (array-safe? (make-specialized-array (make-interval '#(10)) u8-storage-class 42  #t))
       #t)
 
-(test (array-safe? (make-specialized-array (make-interval '#(10)) 42 u8-storage-class #f))
+(test (array-safe? (make-specialized-array (make-interval '#(10)) u8-storage-class 42 #f))
       #f)
 
 (pp "make-specialized-array-from-data error tests")
@@ -1420,7 +1420,6 @@ OTHER DEALINGS IN THE SOFTWARE.
     ((= i random-tests))
   (let ((array
          (make-specialized-array (random-interval)
-                                 0
                                  u1-storage-class)))
     (test (array-elements-in-order? array)
           #t)))
@@ -1433,7 +1432,6 @@ OTHER DEALINGS IN THE SOFTWARE.
     ((= i random-tests))
   (let* ((base
           (make-specialized-array (random-interval 2 5)
-                                  0
                                   u1-storage-class))
          (curried
           (array-curry base (random 1 (array-dimension base)))))
@@ -1476,7 +1474,6 @@ OTHER DEALINGS IN THE SOFTWARE.
     ((= i random-tests))
   (let* ((base
           (make-specialized-array (random-interval 0 6)
-                                  0
                                   u1-storage-class))
          (extracted
           (array-extract base (random-subinterval (array-domain base)))))
@@ -1491,7 +1488,6 @@ OTHER DEALINGS IN THE SOFTWARE.
     ((= i random-tests))
   (let* ((base
           (make-specialized-array (random-interval)
-                                  0
                                   u1-storage-class))
          (domain
           (array-domain base))
@@ -1541,7 +1537,6 @@ OTHER DEALINGS IN THE SOFTWARE.
     ((= i random-tests))
   (let* ((base
           (make-specialized-array (random-interval)
-                                  0
                                   u1-storage-class))
          (domain
           (array-domain base))
@@ -1592,7 +1587,6 @@ OTHER DEALINGS IN THE SOFTWARE.
     ((= i random-tests))
   (let* ((base
           (make-specialized-array (random-nonnegative-interval 1 6)
-                                  0
                                    u1-storage-class))
          (scales
           (random-positive-vector (array-dimension base) 4))
@@ -1619,7 +1613,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 (do ((i 0 (+ i 1)))
     ((= i random-tests))
   (let* ((array
-          (make-specialized-array (random-nonnegative-interval) 0 u8-storage-class))
+          (make-specialized-array (random-nonnegative-interval) u8-storage-class))
          (ignore  ;; compute and cache the results
           (array-elements-in-order? array))
          (sampled-array
@@ -1641,7 +1635,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 (do ((i 0 (+ i 1)))
     ((= i random-tests))
   (let* ((array
-          (make-specialized-array (random-nonnegative-interval 2 4) 0 u8-storage-class))
+          (make-specialized-array (random-nonnegative-interval 2 4) u8-storage-class))
          (d-1
           (- (array-dimension array) 1))
          (ignore
@@ -1720,7 +1714,6 @@ OTHER DEALINGS IN THE SOFTWARE.
                storage-class))
              (specialized-destination
               (make-specialized-array domain
-                                      (storage-class-default storage-class)
                                       storage-class))
              (source
               (make-array domain
@@ -1806,7 +1799,6 @@ OTHER DEALINGS IN THE SOFTWARE.
                           source-storage-class))
              (destination
               (make-specialized-array domain
-                                      (storage-class-default destination-storage-class)
                                       destination-storage-class))
              (destination
               (if (zero? (random 2))
@@ -2813,7 +2805,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                                1)
       "specialized-array-share: The third argument is not a procedure: ")
 
-(test (specialized-array-share (make-specialized-array (make-interval '#(0 0)) 2)
+(test (specialized-array-share (make-specialized-array (make-interval '#(0 0)))
                                (make-interval '#(1))
                                (lambda (i) (values i i)))
       "specialized-array-share: The second argument (a domain) has more elements than the domain of the first argument (an array): ")
@@ -3885,12 +3877,11 @@ OTHER DEALINGS IN THE SOFTWARE.
     ((= d 6))
   (let* ((unsafe-specialized-destination
           (make-specialized-array (make-interval (make-vector d 10))
-                                  0
                                   u1-storage-class))
          (safe-specialized-destination
           (make-specialized-array (make-interval (make-vector d 10))
-                                  0
                                   u1-storage-class
+                                  0
                                   #t))
          (mutable-destination
           (make-array (array-domain safe-specialized-destination)
@@ -4193,7 +4184,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (do ((d 0 (+ d 1)))
     ((= d 6))
-  (let ((A (make-specialized-array (make-interval (make-vector d 1)) 42)))
+  (let ((A (make-specialized-array (make-interval (make-vector d 1)) generic-storage-class 42)))
     (test (apply array-ref A (make-list d 0))
           42)
     (test (apply array-ref 2 (make-list d 0))
@@ -4201,10 +4192,10 @@ OTHER DEALINGS IN THE SOFTWARE.
               "array-ref: The argument is not an array: "
               "array-ref: The first argument is not an array: "))))
 
-(test (array-ref (make-specialized-array (make-interval '#(0 0)) 42) 0 0)
+(test (array-ref (make-specialized-array (make-interval '#(0 0)) generic-storage-class 42) 0 0)
       "array-getter: Array domain is empty: ")
 
-(test (array-set! (make-specialized-array (make-interval '#(0 0)) 42) 42 0 0)
+(test (array-set! (make-specialized-array (make-interval '#(0 0)) generic-storage-class 42) 42 0 0)
       "array-setter: Array domain is empty: ")
 
 (define B-set!
@@ -4234,7 +4225,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (do ((d 0 (+ d 1)))
     ((= d 6))
-  (let ((A (make-specialized-array (make-interval (make-vector d 1)) 10)))
+  (let ((A (make-specialized-array (make-interval (make-vector d 1)) generic-storage-class 10)))
     (apply array-set! A 42 (make-list d 0))
     (test (apply array-ref A (make-list d 0))
           42)


### PR DESCRIPTION
1. Change calling sequence (make-specialized-array interval initial-value storage-class ...) => (make-specialized-array interval storage-class initial-value ...).
2. Add fast path for `%%interval-foldl` for empty intervals.
3. Reformat generic-arrays.scm.
4. Fix typos in srfi-231.scm/srfi-231.html.

I think this would be a good place for another draft.