### PR TITLE
Add examples for array procedures

### DIFF
--- a/srfi-231.html
+++ b/srfi-231.html
@@ -690,6 +690,33 @@
     <p>Implementations with an appropriate homogeneous vector type should define the associated global variable using <code>make-storage-class</code>.  Otherwise, they shall define the associated global variable to <code>#f</code>.</p>
     <h2>Arrays</h2>
     <p>Arrays are a data type distinct from other Scheme data types.</p>
+    <p>In the examples we use a procedure <code>array-unveil</code> that lists the multi-indices and elements of an array in lexicographical order: </p>
+    <pre><code>(define (array-unveil A)
+  (let ((D_A (array-domain A))
+        (A_  (array-getter A)))
+    (interval-for-each (lambda args
+                         (for-each (lambda (arg)
+                                     (display #\space) (display arg))
+                                   args)
+                         (for-each display
+                                   (list &quot; =&gt; &quot; (apply A_ args) #\newline)))
+                       D_A)))</code></pre>
+    <p>For example:</p>
+    <pre><code>(let ((A (make-array (make-interval '#(2 3 2)) list)))
+  (array-unveil A))</code></pre>
+    <p>displays:</p>
+    <pre><code> 0 0 0 =&gt; (0 0 0)
+ 0 0 1 =&gt; (0 0 1)
+ 0 1 0 =&gt; (0 1 0)
+ 0 1 1 =&gt; (0 1 1)
+ 0 2 0 =&gt; (0 2 0)
+ 0 2 1 =&gt; (0 2 1)
+ 1 0 0 =&gt; (1 0 0)
+ 1 0 1 =&gt; (1 0 1)
+ 1 1 0 =&gt; (1 1 0)
+ 1 1 1 =&gt; (1 1 1)
+ 1 2 0 =&gt; (1 2 0)
+ 1 2 1 =&gt; (1 2 1)</code></pre>
     <h3>Parameters</h3>
     <p><b>Parameter: </b><code><a id="specialized-array-default-safe?">specialized-array-default-safe?</a></code></p>
     <p>A parameter as specified in <a href="https://srfi.schemers.org/srfi-39/">SRFI 39</a>. Initially, <code>(specialized-array-default-safe?)</code> returns <code>#f</code>. It is an error to call <code>(specialized-array-default-safe? <var>arg</var>)</code> if <code><var>arg</var></code> is not a boolean.</p>
@@ -799,18 +826,44 @@
 (a_ 11 0) =&gt; is an error</code></pre>
     <p><b>Procedure: </b><code><a id="array-dimension">array-dimension</a> <var>array</var></code></p>
     <p>Shorthand for <code>(interval-dimension (array-domain <var>array</var>))</code>.  It is an error to call this procedure if <code><var>array</var></code> is not an array.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((A (make-array (make-interval '#(3 3)) list))
+      (B (make-array (make-interval '#()) (lambda () 42))))
+  (array-dimension A)   ;; =&gt; 2
+  (array-dimension B))  ;; =&gt; 0</code></pre>
     <p><b>Procedure: </b><code><a id="mutable-array?">mutable-array?</a> <var>obj</var></code></p>
     <p>Returns <code>#t</code> if <code><var>obj</var></code> is a mutable array and <code>#f</code> otherwise.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((A (array-copy (make-array (make-interval '#(2 2)) list)
+                     generic-storage-class
+                     #t))
+      (B (array-copy (make-array (make-interval '#(2 2)) list)
+                     generic-storage-class
+                     #f)))
+  (mutable-array? A)    ;; =&gt; #t
+  (mutable-array? B))   ;; =&gt; #f</code></pre>
     <p><b>Procedure: </b><code><a id="array-setter">array-setter</a> <var>array</var></code></p>
     <p>If <code><var>array</var></code> is an array built by</p>
     <pre><code>(make-array <var>interval</var> <var>getter</var> <var>setter</var>)</code></pre>
-    <p>then <code>array-setter</code> returns <code><var>setter</var></code>. It is an error to call <code>array-setter</code>
+    <p>then <code>array-setter</code> returns <code><var>setter</var></code>. Other procedures can build mutable arrays, e.g., <code>array-copy</code>.  It is an error to call <code>array-setter</code>
       if <code><var>array</var></code> is not a mutable array.</p>
     <p><b>Procedure: </b><code><a id="array-freeze!">array-freeze!</a> <var>A</var></code></p>
     <p>Modifies the array <code><var>A</var></code> so it is not mutable.  Returns the modified argument.</p>
     <p>It is an error if <code><var>A</var></code> is not an array.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((A (array-copy (make-array (make-interval '#(2 2)) list)
+                     generic-storage-class
+                     #t)))
+  (mutable-array? A)  ;; =&gt; #t
+  (array-freeze! A)
+  (mutable-array? A)) ;; =&gt; #f</code></pre>
     <p><b>Procedure: </b><code><a id="array-empty?">array-empty?</a> <var>a</var></code></p>
     <p>Assumes <code><var>a</var></code> is an array, and returns <code>(interval-empty? (array-domain <var>a</var>))</code>.  It is an error if the argument is not an array.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((A (make-array (make-interval '#(2 2)) list))
+      (B (make-array (make-interval '#(4 0 4)) list)))
+  (array-empty? A)   ;; =&gt; #f
+  (array-empty? B))  ;; =&gt; #t</code></pre>
     <p><b>Procedure: </b><code><a id="make-specialized-array">make-specialized-array</a> <var>interval</var> [ <var>storage-class</var> generic-storage-class ] [ <var>initial-value</var> (storage-class-default  <var>storage-class</var> ) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
     <p>Constructs a mutable specialized array from its arguments.</p>
     <p><code><var>interval</var></code> must be given an interval. If given, <code><var>storage-class</var></code> must be a storage class; if it is not given, it defaults to <code>generic-storage-class</code>. If given, <code><var>initial-value</var></code> must be a value that can be manipulated by <code><var>storage-class</var></code>; if it is not given, it defaults to <code>(storage-class-default <var>storage-class</var>)</code>. If given, <code><var>safe?</var></code> must be a boolean; if it is not given, it defaults to the current value of <code>(specialized-array-default-safe?)</code>.</p>
@@ -836,6 +889,16 @@
     <pre><code>  (define (make-u16-array interval)
     (make-specialized-array interval u16-storage-class 0 #f))</code></pre>
     <p>and then simply call, e.g., <code>(make-u16-array (make-interval '#(3 3)))</code>.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((A (make-specialized-array (make-interval '#(2 3)) u8-storage-class 42)))
+  (array-unveil A))</code></pre>
+    <p>displays:</p>
+    <pre><code> 0 0 =&gt; 42
+ 0 1 =&gt; 42
+ 0 2 =&gt; 42
+ 1 0 =&gt; 42
+ 1 1 =&gt; 42
+ 1 2 =&gt; 42</code></pre>
     <p><b>Procedure: </b><code><a id="make-specialized-array-from-data">make-specialized-array-from-data</a> <var>data</var> [ <var>storage-class</var> generic-storage-class ] [ <var>mutable?</var> (specialized-array-default-mutable?) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
     <p>This routine constructs a new specialized array using <code><var>data</var></code> as part of the body of the result without copying.</p>
     <p>This routine exploits the low-level representation of the body of a specialized array of a specific storage class, and as such may not be portable between implementations.  Here are several examples.</p>
@@ -845,6 +908,13 @@
     <p>This routine assumes that <code><var>mutable?</var></code> and <code><var>safe?</var></code>, if given, are booleans, and that <code><var>storage-class</var></code>, if given, is a storage class.  <code><var>data</var></code> must be an object for which <code>((storage-class-data? <var>storage-class</var>) <var>data</var>)</code> returns <code>#t</code>.</p>
     <p>This routine constructs a new one-dimensional array with storage class <code><var>storage-class</var></code>, mutability <code><var>mutable?</var></code>, safety <code><var>safe?</var></code>, body <code>((storage-class-data-&gt;body <var>storage-class</var>) <var>data</var>)</code>, with domain <code>(make-interval (vector <var>N</var>))</code>, where <code><var>N</var></code> is the greatest number of elements one can fit into <code><var>data</var></code>, and indexer <code>(lambda (i) i)</code>.</p>
     <p>It is an error if the arguments do not satisfy these conditions, or if <code><var>mutable?</var></code> is true and <code><var>data</var></code> is not mutable.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((A (make-specialized-array-from-data '#(dog cat bird))))
+  (array-unveil A))</code></pre>
+    <p>displays:</p>
+    <pre><code> 0 =&gt; dog
+ 1 =&gt; cat
+ 2 =&gt; bird</code></pre>
     <p><b>Discussion:</b> Correct transformations on specialized arrays <i>require</i> that the array's indexer, which maps the domain of the array to exact integers that index elements of the one-dimensional body of the array, be <i>affine</i>.  The procedure <code>make-specialized-array-from-data</code> provides a structured way to turn externally-provided data into an array with a known, very simple, one-dimensional affine indexer.  With this start, the programmer can apply array transforms (e.g., <code>array-extract</code>, <code>specialized-array-reshape</code>, etc.) to massage the data into the shape needed.</p>
     <p>For example, to build a zero-dimensional array that stores its single element in a pre-existing vector, one could use the code:</p>
     <pre><code>(pretty-print
@@ -909,6 +979,30 @@
     <p><b>Procedure: </b><code><a id="array-packed?">array-packed?</a> <var>A</var></code></p>
     <p>Assumes that <code><var>A</var></code> is a specialized array, in which case it returns <code>#t</code> if the elements of <code><var>A</var></code>, taken in lexicographical order, are stored in <code>(array-body <var>A</var>)</code> with increasing and consecutive indices, and <code>#f</code> otherwise.</p>
     <p>It is an error if <code><var>A</var></code> is not a specialized array.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((A (make-specialized-array-from-data '#(0 1 2 3)))
+       (B (array-reverse A))
+       (C (array-sample A '#(2))))
+  (array-unveil A)
+  (display (array-packed? A)) (newline)
+  (array-unveil B)
+  (display (array-packed? B)) (newline)  ;; adjacent boxes but decreasing index
+  (array-unveil C)
+  (display (array-packed? C)) (newline)) ;; non-adjacent boxes</code></pre>
+    <p>displays:</p>
+    <pre><code> 0 =&gt; 0
+ 1 =&gt; 1
+ 2 =&gt; 2
+ 3 =&gt; 3
+#t
+ 0 =&gt; 3
+ 1 =&gt; 2
+ 2 =&gt; 1
+ 3 =&gt; 0
+#f
+ 0 =&gt; 0
+ 1 =&gt; 2
+#f</code></pre>
     <p><b>Procedure: </b><code><a id="specialized-array-share">specialized-array-share</a> <var>array</var> <var>new-domain</var> <var>new-domain-&gt;old-domain</var></code></p>
     <p>Constructs a new specialized array that shares the body of the specialized array <code><var>array</var></code>.
       Returns an object that is behaviorally equivalent to a specialized array with the following fields:</p>
@@ -967,6 +1061,24 @@ indexer:       (lambda multi-index
     <p>If <code><var>array</var></code> is a specialized array, then if any of <code><var>result-storage-class</var></code>, <code><var>mutable?</var></code>, <code><var>safe?</var></code> are omitted,  their values are assigned <code>(array-storage-class <var>array</var>)</code>, <code>(mutable-array? <var>array</var>)</code>, and <code>(array-safe? <var>array</var>)</code>, respectively.</p>
     <p>Otherwise, omitted arguments are assigned the values <code>generic-storage-class</code>, <code>(specialized-array-default-mutable?)</code>, and <code>(specialized-array-default-safe?)</code>, respectively.</p>
     <p>It is an error if the arguments do not satisfy these conditions.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((A (make-array (make-interval '#(2 2)) list))
+       (B (array-copy A)))
+  (display (specialized-array? A)) (newline)
+  (array-unveil A)
+  (display (specialized-array? B)) (newline)
+  (array-unveil B))</code></pre>
+    <p>displays:</p>
+    <pre><code>#f
+ 0 0 =&gt; (0 0)
+ 0 1 =&gt; (0 1)
+ 1 0 =&gt; (1 0)
+ 1 1 =&gt; (1 1)
+#t
+ 0 0 =&gt; (0 0)
+ 0 1 =&gt; (0 1)
+ 1 0 =&gt; (1 0)
+ 1 1 =&gt; (1 1)</code></pre>
     <p><b>Procedure: </b><code><a id="array-curry">array-curry</a> <var>array</var> <var>inner-dimension</var></code></p>
     <p>If <code><var>array</var></code> is an array whose domain is an interval  $[l_0,u_0)\times\cdots\times[l_{d-1},u_{d-1})$, and <code><var>inner-dimension</var></code> is an exact integer between $0$ and $d$ (inclusive), then <code>array-curry</code> returns an immutable array with domain $[l_0,u_0)\times\cdots\times[l_{d-\text{inner-dimension}-1},u_{d-\text{inner-dimension}-1})$, each of whose entries is in itself an array with domain $[l_{d-\text{inner-dimension}},u_{d-\text{inner-dimension}})\times\cdots\times[l_{d-1},u_{d-1})$.</p>
     <p>For example, if <code>A</code> and <code>B</code> are defined by </p>
@@ -1042,14 +1154,10 @@ indexer:       (lambda multi-index
     <p><b>Note: </b>Let's denote by <code><var>B</var></code> the result of <code>(array-curry <var>A</var> <var>k</var>)</code>. While the result of calling <code>(array-getter <var>B</var>)</code> is an immutable, mutable, or specialized array according to whether <code><var>A</var></code> itself is immutable, mutable, or specialized, <code><var>B</var></code> is always an immutable array, where <code>(array-getter <var>B</var>)</code>, which returns an array, is computed anew for each call.  If <code>(array-getter <var>B</var>)</code> will be called multiple times with the same arguments, it may be useful to store these results in a specialized array for fast repeated access.</p>
     <p>Please see the note in the discussion of <a href="#array-tile">array-tile</a>.</p>
     <p><b>Example:</b></p>
-    <pre><code>(define a (make-array (make-interval '#(10 10))
-                      list))
-(define a_ (array-getter a))
-(a_ 3 4)  =&gt; (3 4)
-(define curried-a (array-curry a 1))
-(define curried-a_ (array-getter curried-a))
-((array-getter (curried-a_ 3)) 4)
-                    =&gt; (3 4)</code></pre>
+    <pre><code>(let* ((A (make-array (make-interval '#(10 10)) list))
+       (B (array-curry A 1)))
+  (array-ref A 3 4)               ;; =&gt; (3 4)
+  (array-ref (array-ref B 3) 4))  ;; =&gt; (3 4)</code></pre>
     <p><b>Example: </b>NumPy has the operation <a href="https://numpy.org/doc/stable/reference/generated/numpy.squeeze.html">numpy.squeeze</a>, which can eliminate, or &quot;squeeze&quot; out, all axes of an array with length 1.  It can be implemented using <code>partition</code> from SRFI 1 by</p>
     <pre><code>(define (array-squeeze a)
   (call-with-values
@@ -1116,6 +1224,29 @@ indexer:       (lambda multi-index
 </code></pre>
     <p>It is an error if the arguments of <code>array-extract</code> do not satisfy these conditions.</p>
     <p>If <code><var>array</var></code> is a specialized array, the resulting array inherits its mutability and safety from <code><var>array</var></code>.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((A (make-array (make-interval '#(3 3)) list))
+       (B (array-extract A (make-interval '#(1 0) '#(3 2)))))
+  (display &quot;A:\n&quot;)
+  (array-unveil A)
+  (display &quot;B:\n&quot;)
+  (array-unveil B))</code></pre>
+    <p>displays:</p>
+    <pre><code>A:
+ 0 0 =&gt; (0 0)
+ 0 1 =&gt; (0 1)
+ 0 2 =&gt; (0 2)
+ 1 0 =&gt; (1 0)
+ 1 1 =&gt; (1 1)
+ 1 2 =&gt; (1 2)
+ 2 0 =&gt; (2 0)
+ 2 1 =&gt; (2 1)
+ 2 2 =&gt; (2 2)
+B:
+ 1 0 =&gt; (1 0)
+ 1 1 =&gt; (1 1)
+ 2 0 =&gt; (2 0)
+ 2 1 =&gt; (2 1)</code></pre>
     <p><b>Procedure: </b><code><a id="array-tile">array-tile</a> <var>A</var> <var>S</var></code></p>
     <p>Decomposes  the array <code><var>A</var></code> into subarrays, or <i>tiles</i>, specified by <i>cuts</i> perpendicular to the coordinate axes of <code><var>A</var></code>, which are specified by the elements second argument, <code><var>S</var></code>, and returns an array $T$ whose elements are those tiles.</p>
     <p>If the $k$th axis of <code><var>A</var></code> has zero width, then the $k$th component of <code><var>A</var></code> must be a nonempty vector of exact zeros.</p>
@@ -1198,6 +1329,29 @@ indexer:       (lambda multi-index
 </code></pre>
     <p>that employs the same getter as the original array.</p>
     <p>It is an error if the arguments do not satisfy these conditions.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((A (make-array (make-interval '#(2 3)) list))
+       (B (array-translate A '#(1 -3))))
+  (display &quot;A:\n&quot;)
+  (array-unveil A)
+  (interval= (array-domain B) (make-interval '#(1 -3) '#(3 0))) ;; =&gt; #t
+  (display &quot;B:\n&quot;)
+  (array-unveil B))</code></pre>
+    <p>displays:</p>
+    <pre><code>A:
+ 0 0 =&gt; (0 0)
+ 0 1 =&gt; (0 1)
+ 0 2 =&gt; (0 2)
+ 1 0 =&gt; (1 0)
+ 1 1 =&gt; (1 1)
+ 1 2 =&gt; (1 2)
+B:
+ 1 -3 =&gt; (0 0)
+ 1 -2 =&gt; (0 1)
+ 1 -1 =&gt; (0 2)
+ 2 -3 =&gt; (1 0)
+ 2 -2 =&gt; (1 1)
+ 2 -1 =&gt; (1 2)</code></pre>
     <p><b>Procedure: </b><code><a id="array-permute">array-permute</a> <var>array</var> <var>permutation</var></code></p>
     <p>Assumes that <code><var>array</var></code> is a valid array, <code><var>permutation</var></code> is a valid permutation, and that the dimensions of the array and the permutation are the same. The resulting array will have domain <code>(interval-permute (array-domain array) permutation)</code>.</p>
     <p>We begin with an example.  Assume that the domain of <code><var>array</var></code> is represented by the interval  $[0,4)\times[0,8)\times[0,21)\times [0,16)$, as in the example for <code>interval-permute</code>, and the permutation is <code>#(3 0 1 2)</code>.  Then the domain of the new array is the interval $[0,16)\times [0,4)\times[0,8)\times[0,21)$.</p>
@@ -1233,6 +1387,29 @@ indexer:       (lambda multi-index
                      (&pi;<sup>-1</sup> multi-index))))</code></pre>
     <p>The only length-zero permutation is the empty permutation, specified by <code>'#()</code>.</p>
     <p>It is an error to call <code>array-permute</code> if its arguments do not satisfy these conditions.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((A (make-array (make-interval '#(1 3 2)) list))
+       (B (array-permute A '#(2 1 0))))
+  (display &quot;A:\n&quot;)
+  (array-unveil A)
+  (interval= (array-domain B) (make-interval '#(2 3 1))) ;; =&gt; #t
+  (display &quot;B:\n&quot;)
+  (array-unveil B))</code></pre>
+    <p>displays:</p>
+    <pre><code>A:
+ 0 0 0 =&gt; (0 0 0)
+ 0 0 1 =&gt; (0 0 1)
+ 0 1 0 =&gt; (0 1 0)
+ 0 1 1 =&gt; (0 1 1)
+ 0 2 0 =&gt; (0 2 0)
+ 0 2 1 =&gt; (0 2 1)
+B:
+ 0 0 0 =&gt; (0 0 0)
+ 0 1 0 =&gt; (0 1 0)
+ 0 2 0 =&gt; (0 2 0)
+ 1 0 0 =&gt; (0 0 1)
+ 1 1 0 =&gt; (0 1 1)
+ 1 2 0 =&gt; (0 2 1</code></pre>
     <p><b>Procedure: </b><code><a id="array-reverse">array-reverse</a> <var>array</var> #!optional <var>flip?</var></code></p>
     <p>We assume that <code><var>array</var></code> is an array and <code><var>flip?</var></code>, if given, is a vector of booleans whose length is the same as the dimension of <code><var>array</var></code>.  If <code><var>flip?</var></code> is not given, it is set to a vector with length the same as the dimension of <code><var>array</var></code>, all of whose elements are <code>#t</code>.</p>
     <p><code>array-reverse</code> returns a new array  that is specialized,  mutable, or immutable according to whether <code><var>array</var></code> is specialized, mutable, or immutable, respectively.  Informally, if <code>(vector-ref <var>flip?</var> k)</code> is true, then the ordering of multi-indices in the k'th coordinate direction is reversed, and is left undisturbed otherwise.</p>
@@ -1275,26 +1452,28 @@ indexer:       (lambda multi-index
    (apply (array-getter <code><var>array</var></code>)
           (flip-multi-index multi-index))))) </code></pre>
     <p>It is an error if <code><var>array</var></code> and <code><var>flip?</var></code> don't satisfy these requirements.</p>
-    <p>The following example using <code>array-reverse</code> was motivated by <a href="https://funcall.blogspot.com/2020/01/palindromes-redux-and-sufficiently.html">a blog post by Joe Marshall</a>.</p>
+    <p><b>Example: </b>The following example was motivated by <a href="https://funcall.blogspot.com/2020/01/palindromes-redux-and-sufficiently.html">a blog post by Joe Marshall</a>.</p>
     <pre><code>(define (palindrome? s)
-  (let ((n (string-length s)))
-    (or (&lt; n 2)
-        (let* ((a
-                ;; an array accessing the characters of s
-                (make-array (make-interval (vector n))
-                            (lambda (i)
-                              (string-ref s i))))
-               (ra
-                ;; the array accessed in reverse order
-                (array-reverse a))
-               (half-domain
-                (make-interval (vector (quotient n 2)))))
-          (array-every
-           char=?
-           ;; the first half of s
-           (array-extract a half-domain)
-           ;; the reversed second half of s
-           (array-extract ra half-domain))))))
+  (let* ((n
+          (string-length s))
+         (a
+          ;; an array accessing the characters of s
+          (make-array (make-interval (vector n))
+                      (lambda (i)
+                        (string-ref s i))))
+         (ra
+          ;; the characters accessed in reverse order
+          (array-reverse a))
+         (half-domain
+          (make-interval (vector (quotient n 2)))))
+    ;; If n is 0 or 1 the following extracted arrays
+    ;; are empty.
+    (array-every
+     char=?
+     ;; the first half of s
+     (array-extract a half-domain)
+     ;; the reversed second half of s
+     (array-extract ra half-domain))))
 
 (palindrome? &quot;&quot;) =&gt; #t
 (palindrome? &quot;a&quot;) =&gt; #t
@@ -1337,6 +1516,27 @@ indexer:       (lambda multi-index
    (apply (array-getter <code><var>array</var></code>)
           (map * multi-index (vector-&gt;list <code><var>scales</var></code>)))))</code></pre>
     <p>It is an error if <code><var>array</var></code> and <code><var>scales</var></code> don't satisfy these requirements.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((A (make-array (make-interval '#(3 2)) list))
+       (B (array-sample A '#(2 1))))
+  (interval= (array-domain B) (make-interval '#(2 2)))  ;; =&gt; #t
+  (display &quot;A:\n&quot;)
+  (array-unveil A)
+  (display &quot;B:\n&quot;)
+  (array-unveil B))</code></pre>
+    <p>displays:</p>
+    <pre><code>A:
+ 0 0 =&gt; (0 0)
+ 0 1 =&gt; (0 1)
+ 1 0 =&gt; (1 0)
+ 1 1 =&gt; (1 1)
+ 2 0 =&gt; (2 0)
+ 2 1 =&gt; (2 1)
+B:
+ 0 0 =&gt; (0 0)
+ 0 1 =&gt; (0 1)
+ 1 0 =&gt; (2 0)
+ 1 1 =&gt; (2 1)</code></pre>
     <p><b>Procedure: </b><code><a id="array-outer-product">array-outer-product</a> <var>op</var> <var>array1</var> <var>array2</var></code></p>
     <p>Implements the outer product of <code><var>array1</var></code> and <code><var>array2</var></code> with the operator <code><var>op</var></code>, similar to the APL function with the same name.</p>
     <p>Assume that <code><var>array1</var></code> and <code><var>array2</var></code> are arrays and that <code><var>op</var></code> is a procedure of two arguments.  <code><var>array-outer-product</var></code> returns the immutable array</p>
@@ -1348,6 +1548,25 @@ indexer:       (lambda multi-index
     <p>This operation can be considered a partial inverse to <code>array-curry</code>.  It is an error if the arguments do not satisfy these assumptions.</p>
     <p><b>Note: </b>You can see from the above definition that if <code><var>C</var></code> is <code>(array-outer-product <var>op</var> <var>A</var> <var>B</var>)</code>, then each call to <code>(array-getter <var>C</var>)</code> will call <code><var>op</var></code> as well as <code>(array-getter <var>A</var>)</code> and <code>(array-getter <var>B</var>)</code>.  This implies that if all elements of <code><var>C</var></code> are eventually accessed, then <code>(array-getter <var>A</var>)</code> will be called <code>(array-volume <var>B</var>)</code> times; similarly <code>(array-getter <var>B</var>)</code> will be called <code>(array-volume <var>A</var>)</code> times. </p>
     <p>This implies that if <code>(array-getter <var>A</var>)</code> is expensive to compute (for example, if it's returning an array, as does <code>array-curry</code>) then the elements of <code><var>A</var></code> should be precomputed if necessary and stored in a specialized array, typically using <code>array-copy</code>, before that specialized array is passed as an argument to <code>array-outer-product</code>.  In the examples below, the code for Gaussian elimination applies <code>array-outer-product</code> to shared specialized arrays, which are of course themselves specialized arrays; the code for <code>array-inner-product</code> applies <code>array-outer-product</code> to curried arrays, so we apply <code>array-copy</code> to the arguments before passage to <code>array-outer-product</code>.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((A (make-array (make-interval '#(4)) (lambda (i) (* i 10))))
+       (B (make-array (make-interval '#(3)) values))
+       (C (array-outer-product + A B)))
+  (interval= (array-domain C) (make-interval '#(4 3)))  ;; =&gt; #t
+  (array-unveil C))</code></pre>
+    <p>displays:</p>
+    <pre><code> 0 0 =&gt; 0
+ 0 1 =&gt; 1
+ 0 2 =&gt; 2
+ 1 0 =&gt; 10
+ 1 1 =&gt; 11
+ 1 2 =&gt; 12
+ 2 0 =&gt; 20
+ 2 1 =&gt; 21
+ 2 2 =&gt; 22
+ 3 0 =&gt; 30
+ 3 1 =&gt; 31
+ 3 2 =&gt; 32</code></pre>
     <p><b>Procedure: </b><code><a id="array-inner-product">array-inner-product</a> <var>A</var> <var>f</var> <var>g</var> <var>B</var></code></p>
     <p>Assumes that <code><var>f</var></code> and <code><var>g</var></code> are procedures of two arguments and <code><var>A</var></code> and <code><var>B</var></code> are arrays of dimension at least one, with the upper and lower bounds of the last axis of <code><var>A</var></code> the same as those of the first axis of <code><var>B</var></code>. Computes the equivalent of</p>
     <pre><code>(define (array-inner-product <var>A f g B</var>)
@@ -1358,6 +1577,7 @@ indexer:       (lambda multi-index
    (array-copy (array-curry (array-permute <var>B</var> (index-rotate (array-dimension <var>B</var>) 1)))))</code></pre>
     <p>We precompute and store the curried arrays using <code>array-copy</code> for efficiency reasons, as described in <a href="#array-outer-product"><code>array-outer-product</code></a>.</p>
     <p>It is an error if the arguments do not satisfy these constraints.</p>
+    <p>See the extended examples below that use <code>array-inner-product</code>.</p>
     <p><b>Procedure: </b><code><a id="array-map">array-map</a> <var>f</var> <var>array</var> . <var>arrays</var></code></p>
     <p>If <code><var>array</var></code>, <code>(car <var>arrays</var>)</code>, ... all have the same domain and <code><var>f</var></code> is a procedure, then <code>array-map</code>
       returns a new immutable array with the same domain and getter</p>
@@ -1387,6 +1607,48 @@ indexer:       (lambda multi-index
             (let ((a_ (array-getter a)))
               (lambda (i)
                 (+ (a_ i) i))))</code></pre>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((A (make-array (make-interval '#(1 1) '#(5 5)) list))
+       (B (array-map (lambda (arg) (apply * arg)) A)))
+  (display &quot;A:\n&quot;)
+  (array-unveil A)
+  (display &quot;B:\n&quot;)
+  (array-unveil B))</code></pre>
+    <p>displays:</p>
+    <pre><code>A:
+ 1 1 =&gt; (1 1)
+ 1 2 =&gt; (1 2)
+ 1 3 =&gt; (1 3)
+ 1 4 =&gt; (1 4)
+ 2 1 =&gt; (2 1)
+ 2 2 =&gt; (2 2)
+ 2 3 =&gt; (2 3)
+ 2 4 =&gt; (2 4)
+ 3 1 =&gt; (3 1)
+ 3 2 =&gt; (3 2)
+ 3 3 =&gt; (3 3)
+ 3 4 =&gt; (3 4)
+ 4 1 =&gt; (4 1)
+ 4 2 =&gt; (4 2)
+ 4 3 =&gt; (4 3)
+ 4 4 =&gt; (4 4)
+B:
+ 1 1 =&gt; 1
+ 1 2 =&gt; 2
+ 1 3 =&gt; 3
+ 1 4 =&gt; 4
+ 2 1 =&gt; 2
+ 2 2 =&gt; 4
+ 2 3 =&gt; 6
+ 2 4 =&gt; 8
+ 3 1 =&gt; 3
+ 3 2 =&gt; 6
+ 3 3 =&gt; 9
+ 3 4 =&gt; 12
+ 4 1 =&gt; 4
+ 4 2 =&gt; 8
+ 4 3 =&gt; 12
+ 4 4 =&gt; 16</code></pre>
     <p><b>Procedure: </b><code><a id="array-for-each">array-for-each</a> <var>f</var> <var>array</var> . <var>arrays</var></code></p>
     <p>If <code><var>array</var></code>, <code>(car <var>arrays</var>)</code>, ... all have the same domain  and <code><var>f</var></code> is an appropriate procedure, then <code>array-for-each</code>
       calls</p>
@@ -1409,6 +1671,35 @@ indexer:       (lambda multi-index
                    (cons <var>array</var>
                          <var>arrays</var>)))))</code></pre>
     <p>It is an error to call <code>array-for-each</code> if its arguments do not satisfy these conditions.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((A (make-array (make-interval '#(3 3)) list)))
+  (display &quot;A:\n&quot;)
+  (array-unveil A)
+  (newline)
+  (array-for-each (lambda (entry)
+                    (pretty-print (apply + entry)))
+                  A))</code></pre>
+    <p>displays:</p>
+    <pre><code>A:
+ 0 0 =&gt; (0 0)
+ 0 1 =&gt; (0 1)
+ 0 2 =&gt; (0 2)
+ 1 0 =&gt; (1 0)
+ 1 1 =&gt; (1 1)
+ 1 2 =&gt; (1 2)
+ 2 0 =&gt; (2 0)
+ 2 1 =&gt; (2 1)
+ 2 2 =&gt; (2 2)
+
+0
+1
+2
+1
+2
+3
+2
+3
+4</code></pre>
     <p><b>Procedure: </b><code><a id="array-foldl">array-foldl</a> <var>op</var> <var>id</var> <var>array</var> . <var>arrays</var></code></p>
     <p>This procedure is analogous to the left fold of Ocaml or Haskell, which can be defined on lists in Scheme as:</p>
     <pre><code>(define (foldl op id  . lsts)
@@ -1441,7 +1732,7 @@ indexer:       (lambda multi-index
     <pre><code>(apply foldr op id array (map array-&gt;list (cons array arrays)))</code></pre>
     <p>It is an error if <code>(cons <var>array arrays</var>)</code> is not a list of arrays with the same domain, or if <code><var>op</var></code> is not a procedure.</p>
     <p><b>Note: </b>Both <code>array-foldl</code> and <code>array-foldr</code> are implemented using tail-recursive algorithms in the sample implementation.</p>
-    <p><b>Note: </b>If <code><var>op</var></code> is associative with two-sided identity <code><var>id</var></code>, then <code>array-foldl</code> and <code>array-foldr</code> return the same results, but see:</p>
+    <p><b>Example: </b>If <code><var>op</var></code> is associative with two-sided identity <code><var>id</var></code>, then <code>array-foldl</code> and <code>array-foldr</code> return the same results, but see:</p>
     <pre><code>(define a (make-array (make-interval '#(10)) (lambda (i) i)))
 (array-foldl cons '() a)
 =&gt; ((((((((((() . 0) . 1) . 2) . 3) . 4) . 5) . 6) . 7) . 8) . 9)
@@ -1502,6 +1793,15 @@ indexer:       (lambda multi-index
     <p>If it happens that <code><var>pred</var></code> is applied to the results of applying <code>(array-getter <var>array1</var>)</code>, etc., to the last element of <code>interval</code>, then this last call to <code><var>pred</var></code> is in tail position.</p>
     <p>The procedures <code>(array-getter <var>array1</var>)</code>, etc., are applied only to those values of <code>interval</code> necessary to determine the result of <code>array-any</code>.</p>
     <p>It is an error if the arguments do not satisfy these assumptions.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((A (make-array (make-interval '#(240) '#(250)) values))
+      (B (make-array (make-interval '#(250) '#(300)) values)))
+  
+  (define (square? n)
+    (and (exact? (sqrt n)) n))   ;; return the value
+
+  (array-any square? A)    ;; =&gt; #f
+  (array-any square? B))   ;; =&gt; 256, the first nonfalse value</code></pre>
     <p><b>Procedure: </b><code><a id="array-every">array-every</a> <var>pred</var> <var>array1</var> <var>array2</var> ...</code></p>
     <p>Assumes that <code><var>array1</var></code>, <code><var>array2</var></code>, etc., are arrays, all with the same domain, which we'll call <code>interval</code>.  Also assumes that <code><var>pred</var></code> is a procedure that takes as many arguments as there are arrays and returns a single value.</p>
     <p><code>array-every</code> first applies <code>(array-getter <var>array1</var>)</code>, etc., to the first element of <code>interval</code> in lexicographical order, to which values it then applies <code><var>pred</var></code>.</p>
@@ -1510,13 +1810,57 @@ indexer:       (lambda multi-index
     <p>If it happens that <code><var>pred</var></code> is applied to the results of applying <code>(array-getter <var>array1</var>)</code>, etc., to the last element of <code>interval</code>, then this last call to <code><var>pred</var></code> is in tail position.</p>
     <p>The procedures <code>(array-getter <var>array1</var>)</code>, etc., are applied only to those values of <code>interval</code> necessary to determine the result of <code>array-every</code>.</p>
     <p>It is an error if the arguments do not satisfy these assumptions.</p>
+    <p>For an example, see the palindrome example above.</p>
     <p><b>Procedure: </b><code><a id="array-rarrow-list">array-&gt;list</a> <var>array</var></code></p>
     <p>Stores the elements of <code><var>array</var></code> into a newly allocated list in lexicographical order.  It is an error if <code><var>array</var></code> is not an array.</p>
     <p>It is guaranteed that <code>(array-getter <var>array</var>)</code> is called precisely once for each multi-index in <code>(array-domain <var>array</var>)</code> in lexicographical order.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((A (make-specialized-array-from-data '#(2 4 6 8)))
+       (B (array-reverse A)))
+  (pretty-print (array-&gt;list A))
+  (pretty-print (array-&gt;list B)))</code></pre>
+    <p>displays:</p>
+    <pre><code>(2 4 6 8)
+(8 6 4 2)</code></pre>
     <p><b>Procedure: </b><code><a id="list-rarrow-array">list-&gt;array</a> <var>domain</var> <var>l</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>mutable?</var> (specialized-array-default-mutable?) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
     <p>Assumes that <code><var>l</var></code> is a list, <code><var>domain</var></code> is an interval with volume the same as the length of <code><var>l</var></code>,  <code><var>result-storage-class</var></code> is a storage class that can manipulate all the elements of <code><var>l</var></code>, and <code><var>mutable?</var></code> and <code><var>safe?</var></code> are booleans.</p>
     <p>Returns a specialized array with domain <code><var>domain</var></code> whose elements are the elements of the list <code><var>l</var></code> stored in lexicographical order.  The result is mutable or safe depending on the values of <code><var>mutable?</var></code> and <code><var>safe?</var></code>.</p>
     <p>It is an error if the arguments do not satisfy these assumptions, or if any element of  <code><var>l</var></code> cannot be stored in the body of <code><var>result-storage-class</var></code>, and this last error shall be detected and raised.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((l (iota 12))
+       (A (list-&gt;array (make-interval '#(2 2 3)) l))
+       (B (list-&gt;array (make-interval '#(12)) l)))
+  (display &quot;A:\n&quot;)
+  (array-unveil A)
+  (display &quot;B:\n&quot;)
+  (array-unveil B))</code></pre>
+    <p>displays</p>
+    <pre><code>A:
+ 0 0 0 =&gt; 0
+ 0 0 1 =&gt; 1
+ 0 0 2 =&gt; 2
+ 0 1 0 =&gt; 3
+ 0 1 1 =&gt; 4
+ 0 1 2 =&gt; 5
+ 1 0 0 =&gt; 6
+ 1 0 1 =&gt; 7
+ 1 0 2 =&gt; 8
+ 1 1 0 =&gt; 9
+ 1 1 1 =&gt; 10
+ 1 1 2 =&gt; 11
+B:
+ 0 =&gt; 0
+ 1 =&gt; 1
+ 2 =&gt; 2
+ 3 =&gt; 3
+ 4 =&gt; 4
+ 5 =&gt; 5
+ 6 =&gt; 6
+ 7 =&gt; 7
+ 8 =&gt; 8
+ 9 =&gt; 9
+ 10 =&gt; 10
+ 11 =&gt; 11</code></pre>
     <p><b>Procedure: </b><code><a id="list*-rarrow-array">list*-&gt;array</a> <var>d</var> <var>nested-list</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>mutable?</var> (specialized-array-default-mutable?) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
     <p>Assumes that <code><var>d</var></code> is a nonnegative exact integer and, if given, <code><var>storage-class</var></code> is a storage class and <code><var>mutable?</var></code> and <code><var>safe?</var></code> are booleans.</p>
     <p>This routine builds a specialized array of dimension <code><var>d</var></code>, storage class <code><var>storage-class</var></code>, mutability <code><var>mutable?</var></code>, and safety <code><var>safe?</var></code> from <code><var>nested-list</var></code>.  It is assumed that following predicate does not return <code>#f</code> when passed <code><var>nested-list</var></code> and <code><var>d</var></code> as arguments:</p>
@@ -1550,6 +1894,25 @@ indexer:       (lambda multi-index
 (list*-&gt;array 2 '()) =&gt; An empty array with domain (make-interval '#(0 0))
 (list*-&gt;array 2 '(() ())) =&gt; An empty array with domain (make-interval '#(2 0))</code></pre>
     <p>It is an error if the arguments do not satisfy these assumptions.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((A (list*-&gt;array 3 '(((1 2 3)
+                            (4 5 6))
+                           ((7 8 9)
+                            (10 11 12))))))
+  (array-unveil A))</code></pre>
+    <p>displays:</p>
+    <pre><code> 0 0 0 =&gt; 1
+ 0 0 1 =&gt; 2
+ 0 0 2 =&gt; 3
+ 0 1 0 =&gt; 4
+ 0 1 1 =&gt; 5
+ 0 1 2 =&gt; 6
+ 1 0 0 =&gt; 7
+ 1 0 1 =&gt; 8
+ 1 0 2 =&gt; 9
+ 1 1 0 =&gt; 10
+ 1 1 1 =&gt; 11
+ 1 1 2 =&gt; 12</code></pre>
     <p><b>Procedure: </b><code><a id="array-rarrow-list*">array-&gt;list*</a> <var>A</var></code></p>
     <p>Assumes that <code><var>A</var></code> is an array, and returns a newly allocated nested list <code><var>nested-list</var></code>.  If <code><var>A</var></code> is nonempty and has positive dimension and we denote the getter of <code><var>A</var></code> by <code>A_</code>, then <code><var>nested-list</var></code> and <code>A_</code> satisfy</p>
     <pre><code>(A_ i_0 ... i_d-2 i_d-1)
@@ -1562,13 +1925,66 @@ indexer:       (lambda multi-index
 (array-&gt;list* (make-array (make-interval '#(2 0)) error)) =&gt; '(() ())
 (array-&gt;list* (make-array (make-interval '#(0 2)) error)) =&gt; '()</code></pre>
     <p>It is an error if <code><var>A</var></code> is not an array.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((B (array-&gt;list* (make-array (make-interval '#(6 6)) (lambda (i j) (/ (+ 1 i j)))))))
+  (pretty-print B))</code></pre>
+    <p>displays:</p>
+    <pre><code>((1 1/2 1/3 1/4 1/5 1/6)
+ (1/2 1/3 1/4 1/5 1/6 1/7)
+ (1/3 1/4 1/5 1/6 1/7 1/8)
+ (1/4 1/5 1/6 1/7 1/8 1/9)
+ (1/5 1/6 1/7 1/8 1/9 1/10)
+ (1/6 1/7 1/8 1/9 1/10 1/11))</code></pre>
     <p><b>Procedure: </b><code><a id="array-rarrow-vector">array-&gt;vector</a> <var>array</var></code></p>
     <p>Stores the elements of <code><var>array</var></code> into a newly allocated vector in lexicographical order.  It is an error if <code><var>array</var></code> is not an array.</p>
     <p>It is guaranteed that <code>(array-getter <var>array</var>)</code> is called precisely once for each multi-index in <code>(array-domain <var>array</var>)</code> in lexicographical order.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((A (make-specialized-array-from-data '#(2 4 6 8)))
+       (B (array-reverse A)))
+  (pretty-print (array-&gt;vector A))
+  (pretty-print (array-&gt;vector B)))</code></pre>
+    <p>displays:</p>
+    <pre><code>#(2 4 6 8)
+#(8 6 4 2)</code></pre>
     <p><b>Procedure: </b><code><a id="vector-rarrow-array">vector-&gt;array</a> <var>domain</var> <var>v</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>mutable?</var> (specialized-array-default-mutable?) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
     <p>Assumes that <code><var>v</var></code> is a vector, <code><var>domain</var></code> is an interval with volume the same as the length of <code><var>v</var></code>,  <code><var>result-storage-class</var></code> is a storage class that can manipulate all the elements of <code><var>v</var></code>, and <code><var>mutable?</var></code> and <code><var>safe?</var></code> are booleans.</p>
     <p>Returns a specialized array with domain <code><var>domain</var></code> whose elements are the elements of the vector <code><var>v</var></code> stored in lexicographical order.  The result is mutable or safe depending on the values of <code><var>mutable?</var></code> and <code><var>safe?</var></code>.</p>
     <p>It is an error if the arguments do not satisfy these assumptions, or if any element of  <code><var>v</var></code> cannot be stored in the body of <code><var>result-storage-class</var></code>, and this last error shall be detected and raised.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((v (list-&gt;vector (iota 12)))
+       (A (vector-&gt;array (make-interval '#(2 2 3)) v))
+       (B (vector-&gt;array (make-interval '#(12)) v)))
+  (display &quot;A:\n&quot;)
+  (array-unveil A)
+  (display &quot;B:\n&quot;)
+  (array-unveil B))</code></pre>
+    <p>displays:</p>
+    <pre><code>A:
+ 0 0 0 =&gt; 0
+ 0 0 1 =&gt; 1
+ 0 0 2 =&gt; 2
+ 0 1 0 =&gt; 3
+ 0 1 1 =&gt; 4
+ 0 1 2 =&gt; 5
+ 1 0 0 =&gt; 6
+ 1 0 1 =&gt; 7
+ 1 0 2 =&gt; 8
+ 1 1 0 =&gt; 9
+ 1 1 1 =&gt; 10
+ 1 1 2 =&gt; 11
+B:
+ 0 =&gt; 0
+ 1 =&gt; 1
+ 2 =&gt; 2
+ 3 =&gt; 3
+ 4 =&gt; 4
+ 5 =&gt; 5
+ 6 =&gt; 6
+ 7 =&gt; 7
+ 8 =&gt; 8
+ 9 =&gt; 9
+ 10 =&gt; 10
+ 11 =&gt; 11</code></pre>
     <p><b>Procedure: </b><code><a id="vector*-rarrow-array">vector*-&gt;array</a> <var>d</var> <var>nested-vector</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>mutable?</var> (specialized-array-default-mutable?) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
     <p>Assumes that <code><var>d</var></code> is a nonnegative exact integer and, if given, <code><var>storage-class</var></code> is a storage class and <code><var>mutable?</var></code> and <code><var>safe?</var></code> are booleans.</p>
     <p>This routine builds a specialized array of dimension <code><var>d</var></code>, storage class <code><var>storage-class</var></code>, mutability <code><var>mutable?</var></code>, and safety <code><var>safe?</var></code> from <code><var>nested-vector</var></code>.  It is assumed that following predicate does not return <code>#f</code> when passed <code><var>nested-vector</var></code> and <code><var>d</var></code> as arguments:</p>
@@ -1598,6 +2014,25 @@ indexer:       (lambda multi-index
     <p>and we assume that this value can be manipulated by <code><var>storage-class</var></code>.</p>
     <p>If the resulting array would be empty or have dimension zero, see the examples for <code>list*-&gt;array</code>.</p>
     <p>It is an error if the arguments do not satisfy these assumptions.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((A (vector*-&gt;array 3 '#(#(#(1 2 3)
+                                #(4 5 6))
+                              #(#(7 8 9)
+                                #(10 11 12))))))
+  (array-unveil A))</code></pre>
+    <p>displays:</p>
+    <pre><code> 0 0 0 =&gt; 1
+ 0 0 1 =&gt; 2
+ 0 0 2 =&gt; 3
+ 0 1 0 =&gt; 4
+ 0 1 1 =&gt; 5
+ 0 1 2 =&gt; 6
+ 1 0 0 =&gt; 7
+ 1 0 1 =&gt; 8
+ 1 0 2 =&gt; 9
+ 1 1 0 =&gt; 10
+ 1 1 1 =&gt; 11
+ 1 1 2 =&gt; 12</code></pre>
     <p><b>Procedure: </b><code><a id="array-rarrow-vector*">array-&gt;vector*</a> <var>A</var></code></p>
     <p>Assumes that <code><var>A</var></code> is an array, and returns a newly allocated nested vector <code><var>nested-vector</var></code>.  If we denote the getter of <code><var>A</var></code> by <code>A_</code>, then <code><var>nested-vector</var></code> and <code>A_</code> satisfy</p>
     <pre><code>(A_ i_0 ... i_d-2 i_d-1)
@@ -1605,11 +2040,48 @@ indexer:       (lambda multi-index
     <p>If <code><var>A</var></code> is empty or zero dimensional, then see the examples for <code>array-&gt;list*</code>.:</p>
     <p>Each element of <code><var>A</var></code> is accessed once.</p>
     <p>It is an error if <code><var>A</var></code> is not an array.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((B (array-&gt;vector* (make-array (make-interval '#(6 6)) (lambda (i j) (/ (+ 1 i j)))))))
+  (pretty-print B))</code></pre>
+    <p>displays:</p>
+    <pre><code>#(#(1 1/2 1/3 1/4 1/5 1/6)
+  #(1/2 1/3 1/4 1/5 1/6 1/7)
+  #(1/3 1/4 1/5 1/6 1/7 1/8)
+  #(1/4 1/5 1/6 1/7 1/8 1/9)
+  #(1/5 1/6 1/7 1/8 1/9 1/10)
+  #(1/6 1/7 1/8 1/9 1/10 1/11))</code></pre>
     <p><b>Procedure: </b><code><a id="array-assign!">array-assign!</a> <var>destination</var> <var>source</var></code></p>
     <p>Assumes that <code><var>destination</var></code> is a mutable array and <code><var>source</var></code> is an array with the same domain, and that the elements of <code><var>source</var></code> can be stored into <code><var>destination</var></code>.</p>
     <p>Evaluates <code>(array-getter <var>source</var>)</code> on the multi-indices in <code>(array-domain <var>source</var>)</code> in lexicographical order, and assigns each value to the multi-index in <code><var>destination</var></code> in the same lexicographical order.</p>
     <p>It is an error if the arguments don't satisfy these assumptions.</p>
     <p>If assigning any element of <code><var>destination</var></code> affects the value of any element of <code><var>source</var></code>, then the result is undefined.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((A (array-copy
+           (make-array (make-interval '#(5 5))
+                       (lambda (i j) (* i j)))
+           generic-storage-class
+           #t))    ;; ensure A is mutable
+       (D_B (make-interval '#(2 2) '#(5 5)))
+       (B (make-array D_B (lambda (i j) 100))))
+  (display &quot;A before assignment:\n&quot;)
+  (pretty-print (array-&gt;list* A))
+  (array-assign! (array-extract A D_B)
+                 B)
+  (display &quot;A after assignment:\n&quot;)
+  (pretty-print (array-&gt;list* A)))</code></pre>
+    <p>displays:</p>
+    <pre><code>A before assignment:
+((0 0 0 0 0)
+ (0 1 2 3 4)
+ (0 2 4 6 8)
+ (0 3 6 9 12)
+ (0 4 8 12 16))
+A after assignment:
+((0 0 0 0 0)
+ (0 1 2 3 4)
+ (0 2 100 100 100)
+ (0 3 100 100 100)
+ (0 4 100 100 100))</code></pre>
     <p><b>Procedure: </b><code><a id="array-stack">array-stack</a> <var>k</var> <var>arrays</var> [ <var>storage-class</var> [ <var>mutable?</var> [ <var>safe?</var> ] ] ]</code></p>
     <p>Assumes that <code><var>arrays</var></code> is a nonnull list of arrays with identical domains,  <code><var>k</var></code> is an exact integer between 0 (inclusive) and the dimension of the array domains (inclusive), and, if given, <code><var>storage-class</var></code> is a storage class, <code><var>mutable?</var></code> is a boolean, and <code><var>safe?</var></code> is a boolean.</p>
     <p>Returns a specialized array equivalent to</p>
@@ -1677,6 +2149,36 @@ indexer:       (lambda multi-index
   result-array)</code></pre>
     <p>Any missing optional arguments are assigned the values <code>generic-storage-class</code>, <code>(specialized-array-default-mutable?)</code>, and <code>(specialized-array-default-safe?)</code>, respectively.</p>
     <p>It is an error if any of these assumptions are not met, or if the given storage class cannot manipulate the elements of <code><var>A</var></code>'s array elements.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let* ((A (list*-&gt;array 1 '(1 2 3)))
+       (B (list*-&gt;array 1 '(4 5 6)))
+       (C (list*-&gt;array 1 '(7 8 9)))
+       (D (list*-&gt;array 1 '(10 11 12)))
+       (E (list*-&gt;array 1 (list A B C D)))
+       (F (array-decurry E)))
+  (array-every array? E)              ;; =&gt; #t
+  (array-every
+   (lambda (a)
+     (interval=
+      (array-domain a)
+      (make-interval '#(3))))         ;; =&gt; #t
+   E)
+  (interval= (array-domain F)
+             (make-interval '#(4 3))) ;; =&gt; #t
+  (array-unveil F))</code></pre>
+    <p>displays:</p>
+    <pre><code> 0 0 =&gt; 1
+ 0 1 =&gt; 2
+ 0 2 =&gt; 3
+ 1 0 =&gt; 4
+ 1 1 =&gt; 5
+ 1 2 =&gt; 6
+ 2 0 =&gt; 7
+ 2 1 =&gt; 8
+ 2 2 =&gt; 9
+ 3 0 =&gt; 10
+ 3 1 =&gt; 11
+ 3 2 =&gt; 12</code></pre>
     <p><b>Procedure: </b><code><a id="array-append">array-append</a> <var>k</var> <var>arrays</var> [ <var>storage-class</var> [ <var>mutable?</var> [ <var>safe?</var> ] ] ]</code></p>
     <p>Assumes that <code><var>arrays</var></code> is a nonnull list of arrays with domains that differ at most in the <code><var>k</var></code>'th axis,  <code><var>k</var></code> is an exact integer between 0 (inclusive) and the dimension of the array domains (exclusive), and, if given, <code><var>storage-class</var></code> is a storage class, <code><var>mutable?</var></code> is a boolean, and <code><var>safe?</var></code> is a boolean.</p>
     <p>This routine appends, or concatenates, the argument arrays along the <var>k</var>'th axis, with the lower bound of this axis set to 0.</p>
@@ -1883,10 +2385,22 @@ indexer:       (lambda multi-index
     <p>Assumes that <code><var>A</var></code> is an array, and  <code><var>multi-index</var></code> is a sequence of exact integers.</p>
     <p>Returns <code>(apply (array-getter <var>A</var>) <var>multi-index</var>)</code>.</p>
     <p>It is an error if <code><var>A</var></code> is not an array,  if the number of elements in <code><var>multi-index</var></code> is not the the dimension of <code><var>A</var></code>, or if <code><var>multi-index</var></code> is not in the domain of <code><var>A</var></code>, so, in particular, if <code><var>A</var></code> is empty.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((A (make-array (make-interval '#(10000 10000)) expt)))
+  (array-ref A 5 37)  ;; =&gt; 72759576141834259033203125
+  (array-ref A 37 5)) ;; =&gt; 69343957</code></pre>
     <p><b>Procedure: </b><code><a id="array-set!">array-set!</a> <var>A</var> <var>v</var> . <var>multi-index</var></code></p>
     <p>Assumes that <code><var>A</var></code> is a mutable array, that <code><var>v</var></code> is a value that can be stored within that array, and that <code><var>multi-index</var></code> is a sequence of exact integers.</p>
     <p>Returns <code>(apply (array-setter <var>A</var>) <var>v multi-index</var>)</code>.</p>
     <p>It is an error if <code><var>A</var></code> is not a mutable array, if <code><var>v</var></code> is not an appropriate value to be stored in that array, if the number of elements in <code><var>multi-index</var></code> is not the the dimension of <code><var>A</var></code>, or if <code><var>multi-index</var></code> is not in the domain of <code><var>A</var></code>, so, in particular, if <code><var>A</var></code> is empty.</p>
+    <p><b>Example: </b></p>
+    <pre><code>(let ((A (array-copy
+          (list*-&gt;array 1 (iota 1000))
+          generic-storage-class
+          #t)))   ;; ensure array is mutable
+  (array-ref A 500)         ;; =&gt; 500
+  (array-set! A 'grok 500)
+  (array-ref A 500))        ;; =&gt; grok</code></pre>
     <p><b>Note: </b>In the sample implementation, because <code>array-ref</code> and <code>array-set!</code> take a variable number of arguments and they must check that <code><var>A</var></code> is an array of the appropriate type, programs written in a style using these procedures, rather than the style in which <code>1D-Haar-loop</code> is coded below, can take up to three times as long runtime.</p>
     <p><b>Note: </b>In the sample implementation, checking whether the multi-indices are exact integers and within the domain of the array, and checking whether the value is appropriate for storage into the array, is delegated to the underlying definition of the array argument.  If the first argument is a safe specialized array, then these items are checked; if it is an unsafe specialized array, they are not.  If it is a generalized array, it is up to the programmer whether to define the getter and setter of the array to check the correctness of the arguments.</p>
     <p><b>Procedure: </b><code><a id="specialized-array-reshape">specialized-array-reshape</a> <var>array</var> <var>new-domain</var> [ <var>copy-on-failure?</var> #f ]</code></p>

--- a/srfi-231.scm
+++ b/srfi-231.scm
@@ -934,6 +934,31 @@ manipulate exact integer values between -2"(<sup>(<var> 'X)"-1")" and
 
 (<h2> "Arrays")
 (<p> "Arrays are a data type distinct from other Scheme data types.")
+(<p> "In the examples we use a procedure "(<code>'array-unveil)" that lists the multi-indices and elements of an array in lexicographical order: ")
+(<pre>(<code>"(define (array-unveil A)
+  (let ((D_A (array-domain A))
+        (A_  (array-getter A)))
+    (interval-for-each (lambda args
+                         (for-each (lambda (arg)
+                                     (display #\\space) (display arg))
+                                   args)
+                         (for-each display
+                                   (list \" => \" (apply A_ args) #\\newline)))
+                       D_A)))"))
+(<p> "For example:")(<pre>(<code>"(let ((A (make-array (make-interval '#(2 3 2)) list)))
+  (array-unveil A))"))
+(<p> "displays:")(<pre>(<code>" 0 0 0 => (0 0 0)
+ 0 0 1 => (0 0 1)
+ 0 1 0 => (0 1 0)
+ 0 1 1 => (0 1 1)
+ 0 2 0 => (0 2 0)
+ 0 2 1 => (0 2 1)
+ 1 0 0 => (1 0 0)
+ 1 0 1 => (1 0 1)
+ 1 1 0 => (1 1 0)
+ 1 1 1 => (1 1 1)
+ 1 2 0 => (1 2 0)
+ 1 2 1 => (1 2 1)"))
 
 (<h3> "Parameters")
 
@@ -1065,23 +1090,45 @@ It is an error to call "(<code> 'array-domain)" or "(<code> 'array-getter)" if "
 
 (format-lambda-list '(array-dimension array))
 (<p> "Shorthand for "(<code>"(interval-dimension (array-domain "(<var>'array)"))")".  It is an error to call this procedure if "(<code>(<var>'array))" is not an array.")
+(<p>(<b> "Example: "))(<pre>(<code>"(let ((A (make-array (make-interval '#(3 3)) list))
+      (B (make-array (make-interval '#()) (lambda () 42))))
+  (array-dimension A)   ;; => 2
+  (array-dimension B))  ;; => 0"))
 
 (format-lambda-list '(mutable-array? obj))
 (<p> "Returns "(<code>"#t")" if "(<code>(<var> 'obj))" is a mutable array and "(<code> '#f)" otherwise.")
+(<p>(<b> "Example: "))(<pre>(<code>"(let ((A (array-copy (make-array (make-interval '#(2 2)) list)
+                     generic-storage-class
+                     #t))
+      (B (array-copy (make-array (make-interval '#(2 2)) list)
+                     generic-storage-class
+                     #f)))
+  (mutable-array? A)    ;; => #t
+  (mutable-array? B))   ;; => #f"))
 
 (format-lambda-list '(array-setter array))
 (<p> "If "(<code>(<var> 'array))" is an array built by")
 (<pre>
  (<code> "(make-array "(<var> 'interval)" "(<var> 'getter)" "(<var> 'setter)")"))
-(<p> "then "(<code> 'array-setter)" returns "(<code>(<var> 'setter))". It is an error to call "(<code> 'array-setter)"
+(<p> "then "(<code> 'array-setter)" returns "(<code>(<var> 'setter))". Other procedures can build mutable arrays, e.g., "(<code>'array-copy)".  It is an error to call "(<code> 'array-setter)"
 if "(<code>(<var> 'array))" is not a mutable array.")
 
 (format-lambda-list '(array-freeze! A))
 (<p> "Modifies the array "(<code>(<var>'A))" so it is not mutable.  Returns the modified argument.")
 (<p> "It is an error if "(<code>(<var>'A))" is not an array.")
+(<p>(<b> "Example: "))(<pre>(<code>"(let ((A (array-copy (make-array (make-interval '#(2 2)) list)
+                     generic-storage-class
+                     #t)))
+  (mutable-array? A)  ;; => #t
+  (array-freeze! A)
+  (mutable-array? A)) ;; => #f"))
 
 (format-lambda-list '(array-empty? a))
 (<p> "Assumes "(<code>(<var>'a))" is an array, and returns "(<code>"(interval-empty? (array-domain "(<var>'a)"))")".  It is an error if the argument is not an array.")
+(<p>(<b> "Example: "))(<pre>(<code>"(let ((A (make-array (make-interval '#(2 2)) list))
+      (B (make-array (make-interval '#(4 0 4)) list)))
+  (array-empty? A)   ;; => #f
+  (array-empty? B))  ;; => #t"))
 
 
 (format-lambda-list '(make-specialized-array interval
@@ -1123,6 +1170,15 @@ if "(<code>(<var> 'array))" is not a mutable array.")
 "  (define (make-u16-array interval)
     (make-specialized-array interval u16-storage-class 0 #f))"))
 (<p> "and then simply call, e.g., "(<code>"(make-u16-array (make-interval '#(3 3)))")".")
+(<p>(<b> "Example: "))(<pre>(<code>"(let ((A (make-specialized-array (make-interval '#(2 3)) u8-storage-class 42)))
+  (array-unveil A))"))
+(<p> "displays:")
+(<pre>(<code>" 0 0 => 42
+ 0 1 => 42
+ 0 2 => 42
+ 1 0 => 42
+ 1 1 => 42
+ 1 2 => 42"))
 
 (format-lambda-list '(make-specialized-array-from-data data
                                                        #\[ storage-class "generic-storage-class" #\]
@@ -1137,6 +1193,12 @@ if "(<code>(<var> 'array))" is not a mutable array.")
 
 (<p> "This routine constructs a new one-dimensional array with storage class "(<code>(<var>'storage-class))", mutability "(<code>(<var>'mutable?))", safety "(<code>(<var>'safe?))", body "(<code>"((storage-class-data->body "(<var>'storage-class)") "(<var>'data)")")", with domain "(<code>"(make-interval (vector "(<var>'N)"))")", where "(<code>(<var>'N))" is the greatest number of elements one can fit into "(<code>(<var>'data))", and indexer "(<code>"(lambda (i) i)")".")
 (<p> "It is an error if the arguments do not satisfy these conditions, or if "(<code>(<var>'mutable?))" is true and "(<code>(<var>'data))" is not mutable.")
+(<p>(<b> "Example: "))(<pre>(<code>"(let ((A (make-specialized-array-from-data '#(dog cat bird))))
+  (array-unveil A))"))
+(<p> "displays:")
+(<pre>(<code>" 0 => dog
+ 1 => cat
+ 2 => bird"))
 
 (<p>(<b>"Discussion:")" Correct transformations on specialized arrays "(<i>'require)" that the array's indexer, which maps the domain of the array to exact integers that index elements of the one-dimensional body of the array, be "(<i>'affine)".  The procedure "(<code>'make-specialized-array-from-data)" provides a structured way to turn externally-provided data into an array with a known, very simple, one-dimensional affine indexer.  With this start, the programmer can apply array transforms (e.g., "(<code>'array-extract)", "(<code>'specialized-array-reshape)", etc.) to massage the data into the shape needed.")
 (<p>"For example, to build a zero-dimensional array that stores its single element in a pre-existing vector, one could use the code:")
@@ -1209,6 +1271,29 @@ if "(<code>(<var> 'array))" is not a mutable array.")
 (format-lambda-list '(array-packed? A))
 (<p> "Assumes that "(<code>(<var>'A))" is a specialized array, in which case it returns "(<code>'#t)" if the elements of "(<code>(<var>'A))", taken in lexicographical order, are stored in "(<code>"(array-body "(<var>'A)")")" with increasing and consecutive indices, and "(<code>'#f)" otherwise.")
 (<p> "It is an error if "(<code>(<var>'A))" is not a specialized array.")
+(<p>(<b> "Example: "))(<pre>(<code>"(let* ((A (make-specialized-array-from-data '#(0 1 2 3)))
+       (B (array-reverse A))
+       (C (array-sample A '#(2))))
+  (array-unveil A)
+  (display (array-packed? A)) (newline)
+  (array-unveil B)
+  (display (array-packed? B)) (newline)  ;; adjacent boxes but decreasing index
+  (array-unveil C)
+  (display (array-packed? C)) (newline)) ;; non-adjacent boxes"))
+(<p> "displays:")
+(<pre>(<code>" 0 => 0
+ 1 => 1
+ 2 => 2
+ 3 => 3
+#t
+ 0 => 3
+ 1 => 2
+ 2 => 1
+ 3 => 0
+#f
+ 0 => 0
+ 1 => 2
+#f"))
 
 (format-lambda-list '(specialized-array-share array new-domain new-domain->old-domain))
 (<p> "Constructs a new specialized array that shares the body of the specialized array "(<code>(<var> 'array))".
@@ -1290,6 +1375,23 @@ indexer:       (lambda multi-index
 (<p> "If "(<code>(<var>'array))" is a specialized array, then if any of "(<code>(<var>'result-storage-class))", "(<code>(<var>'mutable?))", "(<code>(<var>'safe?))" are omitted,  their values are assigned "(<code>"(array-storage-class "(<var>'array)")")", "(<code>"(mutable-array? "(<var>'array)")")", and "(<code>"(array-safe? "(<var>'array)")")", respectively.")
 (<p> "Otherwise, omitted arguments are assigned the values "(<code>'generic-storage-class)", "(<code>"(specialized-array-default-mutable?)")", and "(<code>"(specialized-array-default-safe?)")", respectively.")
 (<p> "It is an error if the arguments do not satisfy these conditions.")
+(<p>(<b> "Example: "))(<pre>(<code>"(let* ((A (make-array (make-interval '#(2 2)) list))
+       (B (array-copy A)))
+  (display (specialized-array? A)) (newline)
+  (array-unveil A)
+  (display (specialized-array? B)) (newline)
+  (array-unveil B))"))
+(<p>"displays:")
+(<pre>(<code>"#f
+ 0 0 => (0 0)
+ 0 1 => (0 1)
+ 1 0 => (1 0)
+ 1 1 => (1 1)
+#t
+ 0 0 => (0 0)
+ 0 1 => (0 1)
+ 1 0 => (1 0)
+ 1 1 => (1 1)"))
 
 
 (format-lambda-list '(array-curry array inner-dimension))
@@ -1389,16 +1491,10 @@ of whose elements is itself an (immutable) array and ")
 (<p> "Please see the note in the discussion of "(<a> href: "#array-tile" "array-tile")".")
 
 (<p>(<b>"Example:"))
-(<pre>
- (<code>
-"(define a (make-array (make-interval '#(10 10))
-                      list))
-(define a_ (array-getter a))
-(a_ 3 4)  => (3 4)
-(define curried-a (array-curry a 1))
-(define curried-a_ (array-getter curried-a))
-((array-getter (curried-a_ 3)) 4)
-                    => (3 4)"))
+(<pre>(<code>"(let* ((A (make-array (make-interval '#(10 10)) list))
+       (B (array-curry A 1)))
+  (array-ref A 3 4)               ;; => (3 4)
+  (array-ref (array-ref B 3) 4))  ;; => (3 4)"))
 
 (<p> (<b> "Example: ")"NumPy has the operation "(<a> href: "https://numpy.org/doc/stable/reference/generated/numpy.squeeze.html" "numpy.squeeze")", which can eliminate, or \"squeeze\" out, all axes of an array with length 1.  It can be implemented using "(<code>'partition)" from SRFI 1 by")
 (<pre>(<code>"(define (array-squeeze a)
@@ -1474,6 +1570,27 @@ of whose elements is itself an (immutable) array and ")
               ))
 (<p> "It is an error if the arguments of "(<code>'array-extract)" do not satisfy these conditions.")
 (<p> "If "(<code>(<var>'array))" is a specialized array, the resulting array inherits its mutability and safety from "(<code>(<var>'array))".")
+(<p>(<b> "Example: "))(<pre>(<code>"(let* ((A (make-array (make-interval '#(3 3)) list))
+       (B (array-extract A (make-interval '#(1 0) '#(3 2)))))
+  (display \"A:\\n\")
+  (array-unveil A)
+  (display \"B:\\n\")
+  (array-unveil B))"))
+(<p>"displays:")(<pre>(<code>"A:
+ 0 0 => (0 0)
+ 0 1 => (0 1)
+ 0 2 => (0 2)
+ 1 0 => (1 0)
+ 1 1 => (1 1)
+ 1 2 => (1 2)
+ 2 0 => (2 0)
+ 2 1 => (2 1)
+ 2 2 => (2 2)
+B:
+ 1 0 => (1 0)
+ 1 1 => (1 1)
+ 2 0 => (2 0)
+ 2 1 => (2 1)"))
 
 (format-lambda-list '(array-tile A S))
 (<p> "Decomposes  the array "(<code>(<var>'A))" into subarrays, or "(<i>'tiles)", specified by "(<i>'cuts)" perpendicular to the coordinate axes of "(<code>(<var>'A))", which are specified by the elements second argument, "(<code>(<var>'S))", and returns an array $T$ whose elements are those tiles.")
@@ -1569,6 +1686,28 @@ $$
 "))
 (<p> "that employs the same getter as the original array.")
 (<p> "It is an error if the arguments do not satisfy these conditions.")
+(<p>(<b> "Example: "))(<pre>(<code>"(let* ((A (make-array (make-interval '#(2 3)) list))
+       (B (array-translate A '#(1 -3))))
+  (display \"A:\\n\")
+  (array-unveil A)
+  (interval= (array-domain B) (make-interval '#(1 -3) '#(3 0))) ;; => #t
+  (display \"B:\\n\")
+  (array-unveil B))"))
+(<p>"displays:")
+(<pre>(<code>"A:
+ 0 0 => (0 0)
+ 0 1 => (0 1)
+ 0 2 => (0 2)
+ 1 0 => (1 0)
+ 1 1 => (1 1)
+ 1 2 => (1 2)
+B:
+ 1 -3 => (0 0)
+ 1 -2 => (0 1)
+ 1 -1 => (0 2)
+ 2 -3 => (1 0)
+ 2 -2 => (1 1)
+ 2 -1 => (1 2)"))
 
 (format-lambda-list '(array-permute array permutation))
 (<p> "Assumes that "(<code>(<var>'array))" is a valid array, "(<code>(<var>'permutation))" is a valid permutation, and that the dimensions of the array and the permutation are the same. The resulting array will have domain "(<code>"(interval-permute (array-domain array) permutation)")".")
@@ -1616,6 +1755,28 @@ a mutable array, then "(<code>'array-permute)" returns the new mutable array")
                      ("(<unprotected> "&pi;")(<sup>"-1")" multi-index))))"))
 (<p> "The only length-zero permutation is the empty permutation, specified by "(<code>"'#()")".")
 (<p>"It is an error to call "(<code>'array-permute)" if its arguments do not satisfy these conditions.")
+(<p>(<b> "Example: "))(<pre>(<code>"(let* ((A (make-array (make-interval '#(1 3 2)) list))
+       (B (array-permute A '#(2 1 0))))
+  (display \"A:\\n\")
+  (array-unveil A)
+  (interval= (array-domain B) (make-interval '#(2 3 1))) ;; => #t
+  (display \"B:\\n\")
+  (array-unveil B))"))
+(<p>"displays:")
+(<pre>(<code>"A:
+ 0 0 0 => (0 0 0)
+ 0 0 1 => (0 0 1)
+ 0 1 0 => (0 1 0)
+ 0 1 1 => (0 1 1)
+ 0 2 0 => (0 2 0)
+ 0 2 1 => (0 2 1)
+B:
+ 0 0 0 => (0 0 0)
+ 0 1 0 => (0 1 0)
+ 0 2 0 => (0 2 0)
+ 1 0 0 => (0 0 1)
+ 1 1 0 => (0 1 1)
+ 1 2 0 => (0 2 1"))
 
 
 (format-lambda-list '(array-reverse array #!optional flip?))
@@ -1668,28 +1829,30 @@ a mutable array, then "(<code>'array-permute)" returns the new mutable array")
    (apply (array-getter "(<code>(<var>'array))")
           (flip-multi-index multi-index))))) "))
 (<p> "It is an error if "(<code>(<var>'array))" and "(<code>(<var>'flip?))" don't satisfy these requirements.")
-(<p> "The following example using "(<code>'array-reverse)" was motivated by "(<a> href: "https://funcall.blogspot.com/2020/01/palindromes-redux-and-sufficiently.html" "a blog post by Joe Marshall")".")
+(<p> (<b> "Example: ")"The following example was motivated by "(<a> href: "https://funcall.blogspot.com/2020/01/palindromes-redux-and-sufficiently.html" "a blog post by Joe Marshall")".")
 (<pre>
  (<code>
 "(define (palindrome? s)
-  (let ((n (string-length s)))
-    (or (< n 2)
-        (let* ((a
-                ;; an array accessing the characters of s
-                (make-array (make-interval (vector n))
-                            (lambda (i)
-                              (string-ref s i))))
-               (ra
-                ;; the array accessed in reverse order
-                (array-reverse a))
-               (half-domain
-                (make-interval (vector (quotient n 2)))))
-          (array-every
-           char=?
-           ;; the first half of s
-           (array-extract a half-domain)
-           ;; the reversed second half of s
-           (array-extract ra half-domain))))))
+  (let* ((n
+          (string-length s))
+         (a
+          ;; an array accessing the characters of s
+          (make-array (make-interval (vector n))
+                      (lambda (i)
+                        (string-ref s i))))
+         (ra
+          ;; the characters accessed in reverse order
+          (array-reverse a))
+         (half-domain
+          (make-interval (vector (quotient n 2)))))
+    ;; If n is 0 or 1 the following extracted arrays
+    ;; are empty.
+    (array-every
+     char=?
+     ;; the first half of s
+     (array-extract a half-domain)
+     ;; the reversed second half of s
+     (array-extract ra half-domain))))
 
 (palindrome? \"\") => #t
 (palindrome? \"a\") => #t
@@ -1719,9 +1882,6 @@ a mutable array, then "(<code>'array-permute)" returns the new mutable array")
    (apply values
           (map * multi-index (vector->list "(<code>(<var>'scales))")))))"))
 (<p> "with the result inheriting the safety and mutability of "(<code>(<var>'array))".")
-
-
-
 (<p> "Otherwise, if "(<code>(<var>'array))" is mutable, then "(<code>'array-sample)" returns")
 (<pre>
  (<code>
@@ -1745,6 +1905,27 @@ a mutable array, then "(<code>'array-permute)" returns the new mutable array")
    (apply (array-getter "(<code>(<var>'array))")
           (map * multi-index (vector->list "(<code>(<var>'scales))")))))"))
 (<p> "It is an error if "(<code>(<var>'array))" and "(<code>(<var>'scales))" don't satisfy these requirements.")
+(<p>(<b> "Example: "))(<pre>(<code>"(let* ((A (make-array (make-interval '#(3 2)) list))
+       (B (array-sample A '#(2 1))))
+  (interval= (array-domain B) (make-interval '#(2 2)))  ;; => #t
+  (display \"A:\\n\")
+  (array-unveil A)
+  (display \"B:\\n\")
+  (array-unveil B))"))
+(<p> "displays:")
+(<pre>(<code>"A:
+ 0 0 => (0 0)
+ 0 1 => (0 1)
+ 1 0 => (1 0)
+ 1 1 => (1 1)
+ 2 0 => (2 0)
+ 2 1 => (2 1)
+B:
+ 0 0 => (0 0)
+ 0 1 => (0 1)
+ 1 0 => (2 0)
+ 1 1 => (2 1)"))
+
 
 (format-lambda-list '(array-outer-product op array1 array2))
 (<p> "Implements the outer product of "(<code>(<var>'array1))" and "(<code>(<var>'array2))" with the operator "(<code>(<var>'op))", similar to the APL function with the same name.")
@@ -1763,6 +1944,24 @@ a mutable array, then "(<code>'array-permute)" returns the new mutable array")
      " should be precomputed if necessary and stored in a specialized array, typically using "(<code>'array-copy)", before that specialized array is passed as an argument to "(<code>'array-outer-product)".  In the examples below, "
      "the code for Gaussian elimination applies "(<code>'array-outer-product)" to shared specialized arrays, which are of course themselves specialized arrays; the code for "(<code>'array-inner-product)
      " applies "(<code>'array-outer-product)" to curried arrays, so we apply "(<code>"array-copy")" to the arguments before passage to "(<code>'array-outer-product)".")
+(<p>(<b> "Example: "))(<pre>(<code>"(let* ((A (make-array (make-interval '#(4)) (lambda (i) (* i 10))))
+       (B (make-array (make-interval '#(3)) values))
+       (C (array-outer-product + A B)))
+  (interval= (array-domain C) (make-interval '#(4 3)))  ;; => #t
+  (array-unveil C))"))
+(<p> "displays:")
+(<pre>(<code>" 0 0 => 0
+ 0 1 => 1
+ 0 2 => 2
+ 1 0 => 10
+ 1 1 => 11
+ 1 2 => 12
+ 2 0 => 20
+ 2 1 => 21
+ 2 2 => 22
+ 3 0 => 30
+ 3 1 => 31
+ 3 2 => 32"))
 
 (format-lambda-list '(array-inner-product A f g B))
 (<p> "Assumes that "(<code>(<var>'f))" and "(<code>(<var>'g))" are procedures of two arguments and "(<code>(<var>'A))" and "(<code>(<var>'B))" are arrays of dimension at least one, with the upper and lower bounds of the last axis of "(<code>(<var>'A))" the same as those of the first axis of "(<code>(<var>'B))". Computes the equivalent of")
@@ -1774,6 +1973,7 @@ a mutable array, then "(<code>'array-permute)" returns the new mutable array")
    (array-copy (array-curry (array-permute "(<var>'B)" (index-rotate (array-dimension "(<var>'B)") 1)))))"))
 (<p> "We precompute and store the curried arrays using "(<code>'array-copy)" for efficiency reasons, as described in "(<a> href: "#array-outer-product" (<code>'array-outer-product))".")
 (<p> "It is an error if the arguments do not satisfy these constraints.")
+(<p> "See the extended examples below that use "(<code>'array-inner-product)".")
 
 (format-lambda-list '(array-map f array #\. arrays))
 (<p> "If "(<code>(<var> 'array))", "(<code>"(car "(<var> 'arrays)")")", ... all have the same domain and "(<code>(<var> 'f))" is a procedure, then "(<code> 'array-map)"
@@ -1815,6 +2015,47 @@ returns a new immutable array with the same domain and getter")
               (lambda (i)
                 (+ (a_ i) i))))"
 ))
+(<p> (<b> "Example: "))(<pre>(<code>"(let* ((A (make-array (make-interval '#(1 1) '#(5 5)) list))
+       (B (array-map (lambda (arg) (apply * arg)) A)))
+  (display \"A:\\n\")
+  (array-unveil A)
+  (display \"B:\\n\")
+  (array-unveil B))"))
+(<p> "displays:")
+(<pre>(<code>"A:
+ 1 1 => (1 1)
+ 1 2 => (1 2)
+ 1 3 => (1 3)
+ 1 4 => (1 4)
+ 2 1 => (2 1)
+ 2 2 => (2 2)
+ 2 3 => (2 3)
+ 2 4 => (2 4)
+ 3 1 => (3 1)
+ 3 2 => (3 2)
+ 3 3 => (3 3)
+ 3 4 => (3 4)
+ 4 1 => (4 1)
+ 4 2 => (4 2)
+ 4 3 => (4 3)
+ 4 4 => (4 4)
+B:
+ 1 1 => 1
+ 1 2 => 2
+ 1 3 => 3
+ 1 4 => 4
+ 2 1 => 2
+ 2 2 => 4
+ 2 3 => 6
+ 2 4 => 8
+ 3 1 => 3
+ 3 2 => 6
+ 3 3 => 9
+ 3 4 => 12
+ 4 1 => 4
+ 4 2 => 8
+ 4 3 => 12
+ 4 4 => 16"))
 
 
 (format-lambda-list '(array-for-each f array #\. arrays))
@@ -1844,6 +2085,34 @@ calls")
                    (cons "(<var> 'array)"
                          "(<var> 'arrays)")))))"))
 (<p> "It is an error to call "(<code> 'array-for-each)" if its arguments do not satisfy these conditions.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let ((A (make-array (make-interval '#(3 3)) list)))
+  (display \"A:\\n\")
+  (array-unveil A)
+  (newline)
+  (array-for-each (lambda (entry)
+                    (pretty-print (apply + entry)))
+                  A))"))
+(<p>"displays:")
+(<pre>(<code>"A:
+ 0 0 => (0 0)
+ 0 1 => (0 1)
+ 0 2 => (0 2)
+ 1 0 => (1 0)
+ 1 1 => (1 1)
+ 1 2 => (1 2)
+ 2 0 => (2 0)
+ 2 1 => (2 1)
+ 2 2 => (2 2)
+
+0
+1
+2
+1
+2
+3
+2
+3
+4"))
 
 (format-lambda-list '(array-foldl op id array #\. arrays))
 (<p> "This procedure is analogous to the left fold of Ocaml or Haskell, which can be defined on lists in Scheme as:")
@@ -1892,7 +2161,7 @@ calls")
 
 (<p> (<b>"Note: ")"Both "(<code>'array-foldl)" and "(<code>'array-foldr)" are implemented using tail-recursive algorithms in the sample implementation.")
 
-(<p> (<b>"Note: ")"If "(<code>(<var>'op))" is associative with two-sided identity "(<code>(<var>'id))", then "(<code>'array-foldl)" and "(<code>'array-foldr)" return the same results, but see:")
+(<p> (<b>"Example: ")"If "(<code>(<var>'op))" is associative with two-sided identity "(<code>(<var>'id))", then "(<code>'array-foldl)" and "(<code>'array-foldr)" return the same results, but see:")
 (<pre>(<code>
 "(define a (make-array (make-interval '#(10)) (lambda (i) i)))
 (array-foldl cons '() a)
@@ -1958,7 +2227,6 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
 
 
 (format-lambda-list '(array-any pred array1 array2 "..."))
-
 (<p> "Assumes that "(<code>(<var>'array1))", "(<code>(<var>'array2))", etc., are arrays, all with the same domain, which we'll call "(<code>'interval)".  Also assumes that "(<code>(<var>'pred))" is a procedure that takes as many arguments as there are arrays and returns a single value.")
 (<p> (<code>'array-any)" first applies "(<code>"(array-getter "(<var>'array1)")")", etc., to the first element of "(<code>'interval)" in lexicographical order, to which value it then applies "(<code>(<var>'pred))".")
 (<p> "If the result of "(<code>(<var>'pred))" is not "(<code>'#f)", then that result is returned by "(<code>'array-any)".  If the result of "(<code>(<var>'pred))" is "(<code>'#f)", then "(<code>'array-any)" continues with the second element of "(<code>'interval)", etc., returning the first nonfalse value of  "(<code>(<var>'pred))".")
@@ -1966,9 +2234,16 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
 (<p> "If it happens that "(<code>(<var>'pred))" is applied to the results of applying "(<code>"(array-getter "(<var>'array1)")")", etc., to the last element of "(<code>'interval)", then this last call to "(<code>(<var>'pred))" is in tail position.")
 (<p> "The procedures "(<code>"(array-getter "(<var>'array1)")")", etc., are applied only to those values of "(<code>'interval)" necessary to determine the result of "(<code>'array-any)".")
 (<p> "It is an error if the arguments do not satisfy these assumptions.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let ((A (make-array (make-interval '#(240) '#(250)) values))
+      (B (make-array (make-interval '#(250) '#(300)) values)))
+  
+  (define (square? n)
+    (and (exact? (sqrt n)) n))   ;; return the value
+
+  (array-any square? A)    ;; => #f
+  (array-any square? B))   ;; => 256, the first nonfalse value"))
 
 (format-lambda-list '(array-every pred array1 array2 "..."))
-
 (<p> "Assumes that "(<code>(<var>'array1))", "(<code>(<var>'array2))", etc., are arrays, all with the same domain, which we'll call "(<code>'interval)".  Also assumes that "(<code>(<var>'pred))" is a procedure that takes as many arguments as there are arrays and returns a single value.")
 (<p> (<code>'array-every)" first applies "(<code>"(array-getter "(<var>'array1)")")", etc., to the first element of "(<code>'interval)" in lexicographical order, to which values it then applies "(<code>(<var>'pred))".")
 (<p> "If the result of "(<code>(<var>'pred))" is "(<code>'#f)", then that result is returned by "(<code>'array-every)".  If the result of "(<code>(<var>'pred))" is nonfalse, then "(<code>'array-every)" continues with the second element of "(<code>'interval)", etc., returning the first  value of  "(<code>(<var>'pred))" that is "(<code>'#f)".")
@@ -1976,11 +2251,19 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
 (<p> "If it happens that "(<code>(<var>'pred))" is applied to the results of applying "(<code>"(array-getter "(<var>'array1)")")", etc., to the last element of "(<code>'interval)", then this last call to "(<code>(<var>'pred))" is in tail position.")
 (<p> "The procedures "(<code>"(array-getter "(<var>'array1)")")", etc., are applied only to those values of "(<code>'interval)" necessary to determine the result of "(<code>'array-every)".")
 (<p> "It is an error if the arguments do not satisfy these assumptions.")
+(<p> "For an example, see the palindrome example above.")
 
 
 (format-lambda-list '(array->list array) 'array-rarrow-list)
 (<p> "Stores the elements of "(<code>(<var>'array))" into a newly allocated list in lexicographical order.  It is an error if "(<code>(<var>'array))" is not an array.")
 (<p> "It is guaranteed that "(<code>"(array-getter "(<var>'array)")")" is called precisely once for each multi-index in "(<code>"(array-domain "(<var>'array)")")" in lexicographical order.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let* ((A (make-specialized-array-from-data '#(2 4 6 8)))
+       (B (array-reverse A)))
+  (pretty-print (array->list A))
+  (pretty-print (array->list B)))"))
+(<p> "displays:")
+(<pre>(<code>"(2 4 6 8)
+(8 6 4 2)"))
 
 (format-lambda-list '(list->array domain l #\[ result-storage-class "generic-storage-class" #\] #\[ mutable? "(specialized-array-default-mutable?)" #\] #\[ safe? "(specialized-array-default-safe?)" #\]) 'list-rarrow-array)
 (<p> "Assumes that "
@@ -1991,6 +2274,40 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
 (<p> "Returns a specialized array with domain "(<code>(<var>'domain))" whose elements are the elements of the list "(<code>(<var>'l))" stored in lexicographical order.  The result is mutable or safe depending on the values of "
      (<code>(<var> 'mutable?))" and "(<code>(<var>'safe?))".")
 (<p> "It is an error if the arguments do not satisfy these assumptions, or if any element of  "(<code>(<var>'l))" cannot be stored in the body of "(<code>(<var>'result-storage-class))", and this last error shall be detected and raised.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let* ((l (iota 12))
+       (A (list->array (make-interval '#(2 2 3)) l))
+       (B (list->array (make-interval '#(12)) l)))
+  (display \"A:\\n\")
+  (array-unveil A)
+  (display \"B:\\n\")
+  (array-unveil B))"))
+(<p> "displays")
+(<pre>(<code>"A:
+ 0 0 0 => 0
+ 0 0 1 => 1
+ 0 0 2 => 2
+ 0 1 0 => 3
+ 0 1 1 => 4
+ 0 1 2 => 5
+ 1 0 0 => 6
+ 1 0 1 => 7
+ 1 0 2 => 8
+ 1 1 0 => 9
+ 1 1 1 => 10
+ 1 1 2 => 11
+B:
+ 0 => 0
+ 1 => 1
+ 2 => 2
+ 3 => 3
+ 4 => 4
+ 5 => 5
+ 6 => 6
+ 7 => 7
+ 8 => 8
+ 9 => 9
+ 10 => 10
+ 11 => 11"))
 
 (format-lambda-list '(list*->array d nested-list #\[ result-storage-class "generic-storage-class" #\] #\[ mutable? "(specialized-array-default-mutable?)" #\] #\[ safe? "(specialized-array-default-safe?)" #\]) 'list*-rarrow-array)
 (<p> "Assumes that "(<code>(<var>'d))" is a nonnegative exact integer and, if given, "(<code>(<var>'storage-class))" is a storage class and "(<code>(<var>'mutable?))" and "(<code>(<var>'safe?))" are booleans.")
@@ -2029,6 +2346,24 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
 (list*->array 2 '()) => An empty array with domain (make-interval '#(0 0))
 (list*->array 2 '(() ())) => An empty array with domain (make-interval '#(2 0))"))
 (<p> "It is an error if the arguments do not satisfy these assumptions.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let ((A (list*->array 3 '(((1 2 3)
+                            (4 5 6))
+                           ((7 8 9)
+                            (10 11 12))))))
+  (array-unveil A))"))
+(<p> "displays:")
+(<pre>(<code>" 0 0 0 => 1
+ 0 0 1 => 2
+ 0 0 2 => 3
+ 0 1 0 => 4
+ 0 1 1 => 5
+ 0 1 2 => 6
+ 1 0 0 => 7
+ 1 0 1 => 8
+ 1 0 2 => 9
+ 1 1 0 => 10
+ 1 1 1 => 11
+ 1 1 2 => 12"))
 
 (format-lambda-list '(array->list* A) 'array-rarrow-list*)
 (<p> "Assumes that "(<code>(<var>'A))" is an array, and returns a newly allocated nested list "(<code>(<var>'nested-list))".  If "(<code>(<var>'A))" is nonempty and has positive dimension and we denote the getter of "(<code>(<var>'A))" by "(<code>'A_)", then "(<code>(<var>'nested-list))" and "(<code>'A_)" satisfy")
@@ -2043,10 +2378,26 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
 (array->list* (make-array (make-interval '#(2 0)) error)) => '(() ())
 (array->list* (make-array (make-interval '#(0 2)) error)) => '()"))
 (<p> "It is an error if "(<code>(<var>'A))" is not an array.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let ((B (array->list* (make-array (make-interval '#(6 6)) (lambda (i j) (/ (+ 1 i j)))))))
+  (pretty-print B))"))
+(<p>"displays:")
+(<pre>(<code>"((1 1/2 1/3 1/4 1/5 1/6)
+ (1/2 1/3 1/4 1/5 1/6 1/7)
+ (1/3 1/4 1/5 1/6 1/7 1/8)
+ (1/4 1/5 1/6 1/7 1/8 1/9)
+ (1/5 1/6 1/7 1/8 1/9 1/10)
+ (1/6 1/7 1/8 1/9 1/10 1/11))"))
 
 (format-lambda-list '(array->vector array) 'array-rarrow-vector)
 (<p> "Stores the elements of "(<code>(<var>'array))" into a newly allocated vector in lexicographical order.  It is an error if "(<code>(<var>'array))" is not an array.")
 (<p> "It is guaranteed that "(<code>"(array-getter "(<var>'array)")")" is called precisely once for each multi-index in "(<code>"(array-domain "(<var>'array)")")" in lexicographical order.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let* ((A (make-specialized-array-from-data '#(2 4 6 8)))
+       (B (array-reverse A)))
+  (pretty-print (array->vector A))
+  (pretty-print (array->vector B)))"))
+(<p>"displays:")
+(<pre>(<code>"#(2 4 6 8)
+#(8 6 4 2)"))
 
 (format-lambda-list '(vector->array domain v #\[ result-storage-class "generic-storage-class" #\] #\[ mutable? "(specialized-array-default-mutable?)" #\] #\[ safe? "(specialized-array-default-safe?)" #\]) 'vector-rarrow-array)
 (<p> "Assumes that "
@@ -2057,6 +2408,40 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
 (<p> "Returns a specialized array with domain "(<code>(<var>'domain))" whose elements are the elements of the vector "(<code>(<var>'v))" stored in lexicographical order.  The result is mutable or safe depending on the values of "
      (<code>(<var> 'mutable?))" and "(<code>(<var>'safe?))".")
 (<p> "It is an error if the arguments do not satisfy these assumptions, or if any element of  "(<code>(<var>'v))" cannot be stored in the body of "(<code>(<var>'result-storage-class))", and this last error shall be detected and raised.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let* ((v (list->vector (iota 12)))
+       (A (vector->array (make-interval '#(2 2 3)) v))
+       (B (vector->array (make-interval '#(12)) v)))
+  (display \"A:\\n\")
+  (array-unveil A)
+  (display \"B:\\n\")
+  (array-unveil B))"))
+(<p> "displays:")
+(<pre>(<code>"A:
+ 0 0 0 => 0
+ 0 0 1 => 1
+ 0 0 2 => 2
+ 0 1 0 => 3
+ 0 1 1 => 4
+ 0 1 2 => 5
+ 1 0 0 => 6
+ 1 0 1 => 7
+ 1 0 2 => 8
+ 1 1 0 => 9
+ 1 1 1 => 10
+ 1 1 2 => 11
+B:
+ 0 => 0
+ 1 => 1
+ 2 => 2
+ 3 => 3
+ 4 => 4
+ 5 => 5
+ 6 => 6
+ 7 => 7
+ 8 => 8
+ 9 => 9
+ 10 => 10
+ 11 => 11"))
 
 
 (format-lambda-list '(vector*->array d nested-vector #\[ result-storage-class "generic-storage-class" #\] #\[ mutable? "(specialized-array-default-mutable?)" #\] #\[ safe? "(specialized-array-default-safe?)" #\]) 'vector*-rarrow-array)
@@ -2090,6 +2475,24 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
 (<p> "and we assume that this value can be manipulated by "(<code>(<var>'storage-class))".")
 (<p> "If the resulting array would be empty or have dimension zero, see the examples for "(<code>'list*->array)".")
 (<p> "It is an error if the arguments do not satisfy these assumptions.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let ((A (vector*->array 3 '#(#(#(1 2 3)
+                                #(4 5 6))
+                              #(#(7 8 9)
+                                #(10 11 12))))))
+  (array-unveil A))"))
+(<p> "displays:")
+(<pre>(<code>" 0 0 0 => 1
+ 0 0 1 => 2
+ 0 0 2 => 3
+ 0 1 0 => 4
+ 0 1 1 => 5
+ 0 1 2 => 6
+ 1 0 0 => 7
+ 1 0 1 => 8
+ 1 0 2 => 9
+ 1 1 0 => 10
+ 1 1 1 => 11
+ 1 1 2 => 12"))
 
 (format-lambda-list '(array->vector* A) 'array-rarrow-vector*)
 (<p> "Assumes that "(<code>(<var>'A))" is an array, and returns a newly allocated nested vector "(<code>(<var>'nested-vector))".  If we denote the getter of "(<code>(<var>'A))" by "(<code>'A_)", then "(<code>(<var>'nested-vector))" and "(<code>'A_)" satisfy")
@@ -2099,6 +2502,15 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
 (<p> "If "(<code>(<var>'A))" is empty or zero dimensional, then see the examples for "(<code>'array->list*)".:")
 (<p> "Each element of "(<code>(<var>'A))" is accessed once.")
 (<p> "It is an error if "(<code>(<var>'A))" is not an array.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let ((B (array->vector* (make-array (make-interval '#(6 6)) (lambda (i j) (/ (+ 1 i j)))))))
+  (pretty-print B))"))
+(<p>"displays:")
+(<pre>(<code>"#(#(1 1/2 1/3 1/4 1/5 1/6)
+  #(1/2 1/3 1/4 1/5 1/6 1/7)
+  #(1/3 1/4 1/5 1/6 1/7 1/8)
+  #(1/4 1/5 1/6 1/7 1/8 1/9)
+  #(1/5 1/6 1/7 1/8 1/9 1/10)
+  #(1/6 1/7 1/8 1/9 1/10 1/11))"))
 
 (format-lambda-list '(array-assign! destination source))
 (<p> "Assumes that "(<code>(<var>'destination))" is a mutable array and "(<code>(<var>'source))" is an array with the same domain, and that the elements of "(<code>(<var>'source))" can be stored into "(<code>(<var>'destination))".")
@@ -2106,6 +2518,32 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
      "and assigns each value to the multi-index in "(<code>(<var>'destination))" in the same lexicographical order.")
 (<p> "It is an error if the arguments don't satisfy these assumptions.")
 (<p> "If assigning any element of "(<code>(<var>'destination))" affects the value of any element of "(<code>(<var>'source))", then the result is undefined.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let* ((A (array-copy
+           (make-array (make-interval '#(5 5))
+                       (lambda (i j) (* i j)))
+           generic-storage-class
+           #t))    ;; ensure A is mutable
+       (D_B (make-interval '#(2 2) '#(5 5)))
+       (B (make-array D_B (lambda (i j) 100))))
+  (display \"A before assignment:\\n\")
+  (pretty-print (array->list* A))
+  (array-assign! (array-extract A D_B)
+                 B)
+  (display \"A after assignment:\\n\")
+  (pretty-print (array->list* A)))"))
+(<p>"displays:")
+(<pre>(<code>"A before assignment:
+((0 0 0 0 0)
+ (0 1 2 3 4)
+ (0 2 4 6 8)
+ (0 3 6 9 12)
+ (0 4 8 12 16))
+A after assignment:
+((0 0 0 0 0)
+ (0 1 2 3 4)
+ (0 2 100 100 100)
+ (0 3 100 100 100)
+ (0 4 100 100 100))"))
 
 (format-lambda-list '(array-stack k arrays #\[ storage-class #\[ mutable? #\[ safe? #\] #\] #\]))
 (<p> "Assumes that "(<code>(<var>'arrays))" is a nonnull list of arrays with identical domains,  "(<code>(<var>'k))" is an exact integer between 0 (inclusive) and the dimension of the array domains (inclusive), and, if given, "(<code>(<var>'storage-class))" is a storage class, "(<code>(<var>'mutable?))" is a boolean, and "(<code>(<var>'safe?))" is a boolean.")
@@ -2177,6 +2615,35 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
   result-array)"))
 (<p> "Any missing optional arguments are assigned the values "(<code>'generic-storage-class)", "(<code>"(specialized-array-default-mutable?)")", and "(<code>"(specialized-array-default-safe?)")", respectively.")
 (<p> "It is an error if any of these assumptions are not met, or if the given storage class cannot manipulate the elements of "(<code>(<var>'A))"'s array elements.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let* ((A (list*->array 1 '(1 2 3)))
+       (B (list*->array 1 '(4 5 6)))
+       (C (list*->array 1 '(7 8 9)))
+       (D (list*->array 1 '(10 11 12)))
+       (E (list*->array 1 (list A B C D)))
+       (F (array-decurry E)))
+  (array-every array? E)              ;; => #t
+  (array-every
+   (lambda (a)
+     (interval=
+      (array-domain a)
+      (make-interval '#(3))))         ;; => #t
+   E)
+  (interval= (array-domain F)
+             (make-interval '#(4 3))) ;; => #t
+  (array-unveil F))"))
+(<p>"displays:")
+(<pre>(<code>" 0 0 => 1
+ 0 1 => 2
+ 0 2 => 3
+ 1 0 => 4
+ 1 1 => 5
+ 1 2 => 6
+ 2 0 => 7
+ 2 1 => 8
+ 2 2 => 9
+ 3 0 => 10
+ 3 1 => 11
+ 3 2 => 12"))
 
 
 (format-lambda-list '(array-append k arrays #\[ storage-class #\[ mutable? #\[ safe? #\] #\] #\]))
@@ -2389,11 +2856,21 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
 (<p> "Assumes that "(<code>(<var>'A))" is an array, and  "(<code>(<var>'multi-index))" is a sequence of exact integers.")
 (<p> "Returns "(<code>"(apply (array-getter "(<var>'A)") "(<var>'multi-index)")")".")
 (<p> "It is an error if "(<code>(<var>'A))" is not an array,  if the number of elements in "(<code>(<var>'multi-index))" is not the the dimension of "(<code>(<var>'A))", or if "(<code>(<var>'multi-index))" is not in the domain of "(<code>(<var>'A))", so, in particular, if "(<code>(<var>'A))" is empty.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let ((A (make-array (make-interval '#(10000 10000)) expt)))
+  (array-ref A 5 37)  ;; => 72759576141834259033203125
+  (array-ref A 37 5)) ;; => 69343957"))
 
 (format-lambda-list '(array-set! A v #\. multi-index))
 (<p> "Assumes that "(<code>(<var>'A))" is a mutable array, that "(<code>(<var>'v))" is a value that can be stored within that array, and that "(<code>(<var>'multi-index))" is a sequence of exact integers.")
 (<p> "Returns "(<code>"(apply (array-setter "(<var>'A)") "(<var>"v multi-index")")")".")
 (<p> "It is an error if "(<code>(<var>'A))" is not a mutable array, if "(<code>(<var>'v))" is not an appropriate value to be stored in that array, if the number of elements in "(<code>(<var>'multi-index))" is not the the dimension of "(<code>(<var>'A))", or if "(<code>(<var>'multi-index))" is not in the domain of "(<code>(<var>'A))", so, in particular, if "(<code>(<var>'A))" is empty.")
+(<p> (<b> "Example: "))(<pre>(<code>"(let ((A (array-copy
+          (list*->array 1 (iota 1000))
+          generic-storage-class
+          #t)))   ;; ensure array is mutable
+  (array-ref A 500)         ;; => 500
+  (array-set! A 'grok 500)
+  (array-ref A 500))        ;; => grok"))
 
 (<p>(<b> "Note: ")"In the sample implementation, because "(<code>'array-ref)" and "(<code>'array-set!)" take a variable number of arguments and they must check that "(<code>(<var>'A))" is an array of the appropriate type, programs written in a style using these procedures, rather than the style in which "(<code>'1D-Haar-loop)" is coded below, can take up to three times as long runtime.")
 

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -4595,25 +4595,28 @@ OTHER DEALINGS IN THE SOFTWARE.
   ;; ((3 3) (3 4) (3 5) (3 6) (3 7))
   ;; ((4 4) (4 5) (4 6) (4 7) (4 8))
   )
+
 (define (palindrome? s)
-  (let ((n (string-length s)))
-    (or (< n 2)
-        (let* ((a
-                ;; an array accessing the characters of s
-                (make-array (make-interval (vector n))
-                            (lambda (i)
-                              (string-ref s i))))
-               (ra
-                ;; the array in reverse order
-                (array-reverse a))
-               (half-domain
-                (make-interval (vector (quotient n 2)))))
-          (array-every
-           char=?
-           ;; the first half of s
-           (array-extract a half-domain)
-           ;; the second half of s
-           (array-extract ra half-domain))))))
+  (let* ((n
+          (string-length s))
+         (a
+          ;; an array accessing the characters of s
+          (make-array (make-interval (vector n))
+                      (lambda (i)
+                        (string-ref s i))))
+         (ra
+          ;; the characters accessed in reverse order
+          (array-reverse a))
+         (half-domain
+          (make-interval (vector (quotient n 2)))))
+    ;; If n is 0 or 1 the following extracted arrays
+    ;; are empty.
+    (array-every
+     char=?
+     ;; the first half of s
+     (array-extract a half-domain)
+     ;; the reversed second half of s
+     (array-extract ra half-domain))))
 
 (for-each (lambda (s)
             (for-each display


### PR DESCRIPTION
srfi-231.scm:

1.  Add examples for array procedures.

2.  Adapt palindrome example to take advantage of empty arrays.

srfi-231.html:

1.  Regenerate from srfi-231.scm.

test-arrays.scm:

1.  Adapt palindrome example to take advantage of empty arrays.