### PR TITLE
Remove unneeded error checking

### DIFF
--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -2681,12 +2681,13 @@ OTHER DEALINGS IN THE SOFTWARE.
                      (%%array-domain destination)))
                (cond ((or (eq? destination-storage-class generic-storage-class)
                           (and (specialized-array? source)
-                               (let ((compatibility-list
-                                      (assq (%%array-storage-class source)
-                                            %%storage-class-compatibility-alist)))
-                                 (and compatibility-list
-                                      (memq destination-storage-class
-                                            compatibility-list)))))
+                               (or (eq? (%%array-storage-class source) destination-storage-class)
+                                   (let ((compatibility-list
+                                          (assq (%%array-storage-class source)
+                                                %%storage-class-compatibility-alist)))
+                                     (and compatibility-list
+                                          (memq destination-storage-class
+                                                compatibility-list))))))
                       ;; no checks needed
                       (%%interval-for-each
                        (case (%%interval-dimension domain)


### PR DESCRIPTION
Ensure no error checking when destination has generic-storage-class

generic-arrays.scm:

1.  Remove generic-storage-class entries from %%storage-class-compatibility-alist.

2.  in %%move-array-elements, check explicitly whether the destination has generic-storage-class, in which case don't apply the destinations checker before storing items.