### PR TITLE
Improve tests

### DIFF
--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -2714,29 +2714,27 @@ OTHER DEALINGS IN THE SOFTWARE.
                       (storage-class-copier (%%array-storage-class destination))
                       (%%array-packed? source))
                  ;; do a block copy
-                 (begin
-                   (if (not (%%interval-empty? (%%array-domain source)))
-                       (let* ((source-indexer
-                               (%%array-indexer source))
-                              (destination-indexer
-                               (%%array-indexer destination))
-                              (copier
-                               (storage-class-copier (%%array-storage-class source)))
-                              (initial-destination-index
-                               (%%interval-lower-bounds->list (%%array-domain destination)))
-                              (destination-start
-                               (apply destination-indexer initial-destination-index))
-                              (initial-source-index
-                               (%%interval-lower-bounds->list (%%array-domain source)))
-                              (source-start
-                               (apply source-indexer initial-source-index))
-                              (source-end
-                               (fx+ source-start (%%interval-volume (%%array-domain source)))))
-                         (copier (%%array-body destination)
-                                 destination-start
-                                 (%%array-body source)
-                                 source-start
-                                 source-end)))
+                 (let* ((source-indexer
+                         (%%array-indexer source))
+                        (destination-indexer
+                         (%%array-indexer destination))
+                        (copier
+                         (storage-class-copier (%%array-storage-class source)))
+                        (initial-destination-index
+                         (%%interval-lower-bounds->list (%%array-domain destination)))
+                        (destination-start
+                         (apply destination-indexer initial-destination-index))
+                        (initial-source-index
+                         (%%interval-lower-bounds->list (%%array-domain source)))
+                        (source-start
+                         (apply source-indexer initial-source-index))
+                        (source-end
+                         (fx+ source-start (%%interval-volume (%%array-domain source)))))
+                   (copier (%%array-body destination)
+                           destination-start
+                           (%%array-body source)
+                           source-start
+                           source-end)
                    "Block copy")
                  ;; We can step through the elements of destination in order,
                  ;; and the getter of the source doesn't capture any continuations.

--- a/srfi-231.scm
+++ b/srfi-231.scm
@@ -95,6 +95,7 @@ MathJax.Hub.Config({
          (<li> "Revised to fix errata:"
                (<ul>
                 (<li> "2023-01-16 (Add "(<a> href: "#array-assign-erratum" "note")" about invoking the continuations of getters and setters in "(<code>'array-assign!)" more than once.)")))
+         (<li> (<a> href: "commentary.html" "Commentary")" added by author on 2023-09-19.")
          )
 
         (<h2> "Abstract")

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -274,6 +274,9 @@ OTHER DEALINGS IN THE SOFTWARE.
 (test (make-interval '#(-1))
       "make-interval: The argument is not a vector of nonnegative exact integers: ")
 
+(test (make-interval '#(1) '#(0))
+      "make-interval: Each lower-bound must be no greater than the associated upper-bound: ")
+
 
 (pp "interval result tests")
 
@@ -569,6 +572,20 @@ OTHER DEALINGS IN THE SOFTWARE.
           (and (%%every (lambda (x) (>= (car x) (cdr x))) (map cons lower1 lower2))
                (%%every (lambda (x) (<= (car x) (cdr x))) (map cons upper1 upper2))))))
 
+(pp "interval-empty? tests")
+
+(test (interval-empty? 'a)
+      "interval-empty?: The argument is not an interval: ")
+
+(test (interval-empty? (make-interval '#(1) '#(1)))
+      #t)
+
+(test (interval-empty? (make-interval '#(1) '#(2)))
+      #f)
+
+(test (interval-empty? (make-interval '#()))
+      #f)
+
 (next-test-random-source-state!)
 
 (pp "interval-contains-multi-index?  error tests")
@@ -661,7 +678,13 @@ OTHER DEALINGS IN THE SOFTWARE.
 (test (interval-fold-right 1 values 3 (make-interval '#(2 2)))
       "interval-fold-right: The first argument is not a procedure: ")
 
-;;; We'll rely on tests for array-fold[lr] to test interval-fold[lr]
+;;; We'll mainly rely on tests for array-fold[lr] to test interval-fold[lr]
+
+(test (interval-fold-left identity + 0 (make-interval '#(5)))
+      10)
+
+(test (interval-fold-right identity + 0 (make-interval '#(5)))
+      10)
 
 (pp "interval-dilate error tests")
 
@@ -1039,12 +1062,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 (test (make-specialized-array  'a)
       "make-specialized-array: The first argument is not an interval: ")
 
-(test (make-specialized-array (make-interval '#(0) '#(10)) 'a 1)
+(test (make-specialized-array (make-interval '#(0) '#(10)) 'a)
       "make-specialized-array: The second argument is not a storage-class: ")
 
 (test (make-specialized-array (make-interval '#(0) '#(10)) u16-storage-class 'a)
       "make-specialized-array: The third argument cannot be manipulated by the second (a storage class): ")
-
 
 (test (make-specialized-array (make-interval '#(0) '#(10)) generic-storage-class 'a 'a)
       "make-specialized-array: The fourth argument is not a boolean: ")
@@ -1100,6 +1122,12 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (test (make-specialized-array-from-data 'a)
       "make-specialized-array-from-data: The first argument is not compatible with the storage class: ")
+
+;;; FIXME: When I figure out how to make immutable data in the interpreter, I'll get this test to work.
+
+#;
+(test (make-specialized-array-from-data "123" char-storage-class #t)
+      "make-specialized-array-from-data: Cannot make mutable array from immutable data: ")
 
 (let ((test-values
        (list ;;       storae-class   default other data
@@ -1510,6 +1538,21 @@ OTHER DEALINGS IN THE SOFTWARE.
     (lambda ()
       (vector-ref storage-classes (random n)))))
 
+(pp "array-empty? tests")
+
+(test (array-empty? 'a)
+      "array-empty?: The argument is not an array: ")
+
+(test (array-empty? (make-array (make-interval '#(1) '#(1)) list))
+      #t)
+
+(test (array-empty? (make-array (make-interval '#(1) '#(2)) list))
+      #f)
+
+(test (array-empty? (make-array (make-interval '#()) list))
+      #f)
+
+
 (pp "array-packed? tests")
 
 ;; We'll use specialized arrays with u1-storage-class---we never
@@ -1801,7 +1844,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 
-(do ((d 1 (fx+ d 1)))
+(do ((d 0 (fx+ d 1)))
     ((= d 6))
   (let* ((uppers-list
           (iota d 2))
@@ -1836,10 +1879,12 @@ OTHER DEALINGS IN THE SOFTWARE.
                   "Block copy"))
         (test (myarray= specialized-source specialized-destination)
               #t)
-        ;; copy to non-adjacent elements of destination, no checking needed
+        ;; copy to (perhaps) non-adjacent elements of destination, no checking needed
         (test (%%move-array-elements (array-reverse specialized-destination) specialized-source "test: ")
               (if (array-packed? (array-reverse specialized-destination))
-                  "No checks needed"
+                  (if (storage-class-copier storage-class)
+                      "Block copy"
+                      "In order, no checks needed")
                   "No checks needed"))
         (test (myarray= specialized-source (array-reverse specialized-destination))
               #t)
@@ -1866,7 +1911,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (next-test-random-source-state!)
 
-(do ((d 1 (fx+ d 1)))
+(do ((d 0 (fx+ d 1)))
     ((= d 6))
   (let* ((uppers-list
           (iota d 2))
@@ -4535,7 +4580,7 @@ OTHER DEALINGS IN THE SOFTWARE.
     ((= i random-tests))
   (let* ((arrays
           (map (lambda (ignore)
-                 (make-array (random-interval 0 5) list))
+                 (make-array (random-interval 0 6) list))
                (make-list 2))))
     (myarray= (apply array-outer-product append arrays)
                     (make-array (apply my-interval-cartesian-product (map array-domain arrays))
@@ -4573,6 +4618,29 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (test (array-ref A-ref 4 5)
       0)
+
+(let ((A (array-copy (make-array (make-interval '#(1 1 1 1 1 1)) list)))
+      (B (array-copy (make-array (make-interval '#(-1 -1 -1 -1 -1 -1)
+                                                '#( 1  1  1  1  1  1))
+                                 list))))
+  ;; We copied A and B so they would have the default error checking.
+  (test (array-ref A 0)
+        "array-getter: multi-index is not the correct dimension: ")
+  (test (array-ref B 0)
+        "array-getter: multi-index is not the correct dimension: ")
+  (test (array-ref A 0 0 0 0 0 0 0)
+        "array-getter: multi-index is not the correct dimension: ")
+  (test (array-ref B 0 0 0 0 0 0 0)
+        "array-getter: multi-index is not the correct dimension: " )
+  (test (array-set! A 0 0)
+        "array-setter: multi-index is not the correct dimension: ")
+  (test (array-set! B 0 0)
+        "array-setter: multi-index is not the correct dimension: ")
+  (test (array-set! A 0 0 0 0 0 0 0 0)
+        "array-setter: multi-index is not the correct dimension: ")
+  (test (array-set! B 0 0 0 0 0 0 0 0)
+        "array-setter: multi-index is not the correct dimension: " ))
+
 
 (do ((d 0 (+ d 1)))
     ((= d 6))

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -2523,7 +2523,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 
-(pp "array-fold[lr] error tests")
+(pp "array-fold-left, array-fold-right error tests")
 
 (test (array-fold-left 1 1 1)
       "array-fold-left: The first argument is not a procedure: ")
@@ -6814,7 +6814,7 @@ that computes the componentwise products when we need them, the times are
                 1))))
        (A (make-array domain A_))
        (array-list '()))
-  (let ((temp (array-append 1 (list A B))))
+  (let ((temp (array-append! 1 (list A B))))
     (set! array-list (cons temp array-list)))
   (if call-cont
       (begin
@@ -6904,7 +6904,5 @@ that computes the componentwise products when we need them, the times are
       (begin
         (set! call-cont #f)
         (cont 4))))
-
-
 
 (for-each display (list "Failed " failed-tests " out of " total-tests " total tests.\n"))


### PR DESCRIPTION
A bug in GCC (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64928) that prevented test coverage of generic-arrays.scm no longer presents in GCC 12.3 or later.

These changes were made after checking that test-arrays.scm exercises all of generic-arrays.scm.

generic-arrays.scm:

1.  In %%move-array-elements, remove a redundant test.

test-arrays.scm:

1. make-interval: Test that it rejects intervals with a lower bound greater than an upper bound.

2. interval-empty?: Test for error conditions, trivial unit tests.

3. interval-fold-{left|right}: add non-error tests.

4: make-specialized-array: test two-argument version with an error in second argument.

5. make-specialized-array-from-data: Add placeholder to test making mutable array from immutable data.

6: array-empty?: Add error and trivial unit tests.

7: %%move-array-elements: Add zero-dimensional arrays to tests.  Fix reversed array tests.

8: array-outer-product: test specialized-arrays with > 4 dimensional arrays.

9. array-{ref|set!}: Check error processing with > 4 dimensional arrays.

srfi-231.scm:

1.  Add line to generate link to commentary.