### PR TITLE
Copy list arguments to array-append and array-stack

### DIFF
--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -4835,7 +4835,8 @@ OTHER DEALINGS IN THE SOFTWARE.
         ((not (boolean? safe?))
          (error (string-append caller "Expecting a boolean as the fifth argument: ") k arrays storage-class mutable? safe?))
         (else
-         (%%%array-stack k arrays storage-class mutable? safe? caller call/cc-safe?))))
+         ;; We copy the arrays argument in case any of the array getters modify the arrays list argument
+         (%%%array-stack k (list-copy arrays) storage-class mutable? safe? caller call/cc-safe?))))
 
 (define (array-append k
                       arrays
@@ -4904,6 +4905,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                              (cdr arrays))))))
            (lambda (axis-subdividers kth-size)
              (let* ((arrays
+                     (list-copy arrays))  ;; in case any of the array getters modify the arrays list argument
+                    (arrays
                      (if call/cc-safe?
                          (map (lambda (A)
                                 (%%->specialized-array A storage-class caller))


### PR DESCRIPTION
generic-arrays.scm:

1.  array-append and array-stack: In the face of mutable pairs and general functions as array getters, copy list arguments to array-append and array-stack before calling any array getters.

This will make it less likely for the sample implementation to crash if compiled to unsafe code or to give unhelpful error messages in case an array getter modifies the list argument to the procedures.