### PR TITLE
Change error processing in make-specialized-array-from-data

### DIFF
--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -2330,11 +2330,8 @@ OTHER DEALINGS IN THE SOFTWARE.
          (error "make-specialized-array-from-data: The second argument is not a storage class: " data storage-class))
         ((not ((storage-class-data? storage-class) data))
          (error "make-specialized-array-from-data: The first argument is not compatible with the storage class: " data))
-        ((and mutable?
-              (not (##mutable? data)))
-         (error "make-specialized-array-from-data: Cannot make mutable array from immutable data: " data storage-class mutable? safe?))
         (else
-         (%%make-specialized-array-from-data data storage-class mutable? safe?))))
+         (%%make-specialized-array-from-data data storage-class mutable? (and mutable? (##mutable? data))))))
 
 
 (define (%%make-specialized-array-from-data data storage-class mutable? safe?)

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -1126,8 +1126,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 ;;; FIXME: When I figure out how to make immutable data in the interpreter, I'll get this test to work.
 
 #;
-(test (make-specialized-array-from-data "123" char-storage-class #t)
-      "make-specialized-array-from-data: Cannot make mutable array from immutable data: ")
+(let ((array (make-specialized-array-from-data "123" char-storage-class #t)))
+  (test (and (array? array)
+             (not (mutable-array? array)))
+        #t))
 
 (let ((test-values
        (list ;;       storae-class   default other data


### PR DESCRIPTION
generic-arrays.scm:

1.  make-specialized-array-from-data: Do not throw an error if asked to make a mutable array from immutable data.  Instead, make an immutable array.  This behavior satisfies the "it is an error" statement, and probably should have been the behavior in the document.

test-arrays.scm:

1.  Revise the (currently unexecuted) test,