### PR TITLE
Small fixes from examining chibi implementation

### DIFF
--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -1188,7 +1188,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                                  data)))))))
             '(generic s8       u8       s16       u16       s32       u32       s64       u64       f32       f64       char)
             '(vector  s8vector u8vector s16vector u16vector s32vector u32vector s64vector u64vector f32vector f64vector string)
-            '(#f      0        0        0         0         0         0         0         0         0.0        0.0     #\0)
+            '(#f      0        0        0         0         0         0         0         0         0.0        0.0     #\null)
             `((lambda (x) #t)                        ; generic
               (lambda (x)                            ; s8
                 (and (fixnum? x)

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -1132,7 +1132,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 (let ((test-values
        (list ;;       storae-class   default other data
         (list generic-storage-class  #f 'a 1 #\c)
-        (list    char-storage-class  '#\0 '#\a '#\b)
+        (list    char-storage-class  '#\null '#\a '#\b)
         (list      u1-storage-class  0 1)
         (list      u8-storage-class  0 23)
         (list     u16-storage-class  0 500)
@@ -2228,6 +2228,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
               ;; We gotta make sure than the error checks work in all dimensions ...
+
+              (test (array-copy (make-array (make-interval '#()) list)
+                                u16-storage-class)
+                    (wrap "Not all elements of the source can be stored in destination: "))
 
               (test (array-copy (make-array (make-interval '#(1) '#(2))
                                             list)


### PR DESCRIPTION
generic-arrays.scm:

1.  Set the default value for char-storage-class to #\null, not the character "0" (#\0),

test-arrays.scm:

1.  Use #\null as default value for char-storage-class in tests.

2.  Add test for zero-dimensional error check.