### PR TITLE
More small fixes.

### DIFF
--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -3390,30 +3390,22 @@ OTHER DEALINGS IN THE SOFTWARE.
                 (widths (%%interval-widths domain)))
            (let slice-widths-check ((k 0))
              (if (fx< k A-dim)
-                 (let ((S_k (vector-ref slice-widths k)))
-                   (if (eqv? (%%interval-width domain k) 0)
-                       (if (and (vector? S_k)
-                                (not (fx= (vector-length S_k) 0))
-                                (%%vector-every (lambda (x) (eqv? x 0)) S_k))
-                           (slice-widths-check (fx+ k 1))
-                           (error (string-append "array-tile: Axis "
-                                                 (number->string k)
-                                                 " of the domain of the first argument has width 0, but element "
-                                                 (number->string k)
-                                                 " of the second argument is not a nonempty vector of exact zeros: ")
-                                  A slice-widths))
-                       (if (or (and (exact-integer? S_k)
-                                    (positive? S_k))
-                               (and (vector? S_k)
-                                    (%%vector-every (lambda (x) (and (exact-integer? x) (not (negative? x)))) S_k)
-                                    (= (%%vector-fold-left (lambda (x y) (+ x y)) 0 S_k) (%%interval-width domain k))))
-                           (slice-widths-check (fx+ k 1))
-                           (error (string-append "array-tile: Axis "
-                                                 (number->string k)
-                                                 " of the domain of the first argument has nonzero width, but element "
-                                                 (number->string k)
-                                                 " of the second argument is neither an exact positive integer nor a vector of nonnegative exact integers summing to that width: ")
-                                  A slice-widths))))
+                 (let ((S_k (vector-ref slice-widths k))
+                       (width (%%interval-width domain k)))
+                   (if (or (and (exact-integer? S_k)
+                                (positive? S_k)
+                                (not (eqv? width 0)))
+                           (and (vector? S_k)
+                                (not (eqv? (vector-length S_k) 0))
+                                (%%vector-every (lambda (x) (and (exact-integer? x) (not (negative? x)))) S_k)
+                                (= (%%vector-fold-left (lambda (x y) (+ x y)) 0 S_k) width)))
+                       (slice-widths-check (fx+ k 1))
+                       (error (string-append "array-tile: Element "
+                                             (number->string k)
+                                             " of the second argument is neither a positive exact integer (allowed if the width of the first argument's corresponding axis is positive) nor a nonempty vector of nonnegative exact integers summing to the width of axis "
+                                             (number->string k)
+                                             " of the first argument: ")
+                              A slice-widths)))
                  (let ((offsets (make-vector A-dim)))
                    (do ((k 0 (fx+ k 1)))
                        ((fx= k A-dim))
@@ -4516,24 +4508,24 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (define %%array-reduce
   (let ((%%array-reduce-base (list 'base)))
-    (lambda (sum A caller)
-      (if (%%array-empty? A)
-          (error (string-append caller "Attempting to reduce over an empty array: ") sum A)
-          (%%interval-fold-left (%%array-getter A)
-                                (lambda (id a)
-                                  (if (eq? id %%array-reduce-base)
-                                      a
-                                      (sum id a)))
-                                %%array-reduce-base
-                                (%%array-domain A))))))
+    (lambda (sum A)
+      (%%interval-fold-left (%%array-getter A)
+                            (lambda (id a)
+                              (if (eq? id %%array-reduce-base)
+                                  a
+                                  (sum id a)))
+                            %%array-reduce-base
+                            (%%array-domain A)))))
 
 (define (array-reduce sum A)
   (cond ((not (array? A))
          (error "array-reduce: The second argument is not an array: " sum A))
         ((not (procedure? sum))
          (error "array-reduce: The first argument is not a procedure: " sum A))
+        ((%%array-empty? A)
+         (error "array-reduce: Attempting to reduce over an empty array: " sum A))
         (else
-         (%%array-reduce sum A "array-reduce: "))))
+         (%%array-reduce sum A))))
 
 (define (%%array->reversed-list array)
   ;; safe in the face of (%%array-getter array) capturing
@@ -4706,12 +4698,9 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (define (%%array-inner-product A f g B)
   ;; Copy the curried arrays for efficiency.
-  ;; If any of the curried arrays are empty, that's OK,
-  ;; If the elements of the curried arrays are empty, then
-  ;; the error check in %%array-reduce will catch it.
   (%%array-outer-product
    (lambda (a b)
-     (%%array-reduce f (%%array-map g a (list b)) "array-inner-product: "))
+     (%%array-reduce f (%%array-map g a (list b))))
    (array-copy (%%array-curry A 1))
    (array-copy (%%array-curry (%%array-permute B (%%index-rotate (%%array-dimension B) 1)) 1))))
 
@@ -4737,6 +4726,9 @@ OTHER DEALINGS IN THE SOFTWARE.
                           (%%interval-upper-bound B-dom 0)))))
          (error (string-append "array-inner-product: The bounds of the last dimension of the first argument "
                                "are not the same as the bounds of the first dimension of the fourth argument: ")
+                A f g B))
+        ((eqv? (%%interval-width (%%array-domain B) 0) 0)
+         (error "array-inner-product: The width of the first axis of the fourth argument is zero: "
                 A f g B))
         (else
          (%%array-inner-product A f g B))))

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -497,11 +497,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (next-test-random-source-state!)
 
-
-(pp "interval-contains-multi-index? error tests")
-
-
-
 (pp "interval-volume error tests")
 
 (test (interval-volume #f)
@@ -3554,9 +3549,10 @@ OTHER DEALINGS IN THE SOFTWARE.
            (lower-bounds (interval-lower-bounds->vector int))
            (upper-bounds (interval-upper-bounds->vector int))
            (permutation (random-permutation (vector-length lower-bounds))))
-      (interval= (interval-permute int permutation)
-                 (make-interval (vector-permute lower-bounds permutation)
-                                (vector-permute upper-bounds permutation))))))
+      (test (interval= (interval-permute int permutation)
+                       (make-interval (vector-permute lower-bounds permutation)
+                                      (vector-permute upper-bounds permutation)))
+            #t))))
 
 (next-test-random-source-state!)
 
@@ -3988,18 +3984,17 @@ OTHER DEALINGS IN THE SOFTWARE.
 (test (array-tile (make-array (make-interval '#(0 0) '#(10 10)) list) 'a)
       "array-tile: The second argument is not a vector of the same length as the dimension of the array first argument: ")
 (test (array-tile (make-array (make-interval '#(0 0) '#(10 10)) list) '#(a a))
-      "array-tile: Axis 0 of the domain of the first argument has nonzero width, but element 0 of the second argument is neither an exact positive integer nor a vector of nonnegative exact integers summing to that width: ")
+      "array-tile: Element 0 of the second argument is neither a positive exact integer (allowed if the width of the first argument's corresponding axis is positive) nor a nonempty vector of nonnegative exact integers summing to the width of axis 0 of the first argument: ")
 (test (array-tile (make-array (make-interval '#(0 0) '#(10 10)) list) '#(-1 1))
-      "array-tile: Axis 0 of the domain of the first argument has nonzero width, but element 0 of the second argument is neither an exact positive integer nor a vector of nonnegative exact integers summing to that width: ")
+      "array-tile: Element 0 of the second argument is neither a positive exact integer (allowed if the width of the first argument's corresponding axis is positive) nor a nonempty vector of nonnegative exact integers summing to the width of axis 0 of the first argument: ")
 (test (array-tile (make-array (make-interval '#(0 0) '#(10 10)) list) '#(10))
       "array-tile: The second argument is not a vector of the same length as the dimension of the array first argument: ")
 (test (array-tile (make-array (make-interval '#(4)) list) '#(#(0 3 0 -1 2)))
-      "array-tile: Axis 0 of the domain of the first argument has nonzero width, but element 0 of the second argument is neither an exact positive integer nor a vector of nonnegative exact integers summing to that width: ")
+      "array-tile: Element 0 of the second argument is neither a positive exact integer (allowed if the width of the first argument's corresponding axis is positive) nor a nonempty vector of nonnegative exact integers summing to the width of axis 0 of the first argument: ")
 (test (array-tile (make-array (make-interval '#(4)) list) '#(#(0 3 0 0 2)))
-      "array-tile: Axis 0 of the domain of the first argument has nonzero width, but element 0 of the second argument is neither an exact positive integer nor a vector of nonnegative exact integers summing to that width: ")
-
+      "array-tile: Element 0 of the second argument is neither a positive exact integer (allowed if the width of the first argument's corresponding axis is positive) nor a nonempty vector of nonnegative exact integers summing to the width of axis 0 of the first argument: ")
 (test (array-tile (make-array (make-interval '#(0)) list) '#(2))
-      "array-tile: Axis 0 of the domain of the first argument has width 0, but element 0 of the second argument is not a nonempty vector of exact zeros: ")
+      "array-tile: Element 0 of the second argument is neither a positive exact integer (allowed if the width of the first argument's corresponding axis is positive) nor a nonempty vector of nonnegative exact integers summing to the width of axis 0 of the first argument: ")
 
 (do ((d 1 (fx+ d 1)))
      ((fx= d 6))
@@ -5691,7 +5686,7 @@ that computes the componentwise products when we need them, the times are
 
 (test (array-inner-product (make-array (make-interval '#(1 10)) list)
                            list list
-                           (make-array (make-interval '#(0 10)) list))
+                           (make-array (make-interval '#(2 10)) list))
       "array-inner-product: The bounds of the last dimension of the first argument are not the same as the bounds of the first dimension of the fourth argument: ")
 
 
@@ -5713,10 +5708,9 @@ that computes the componentwise products when we need them, the times are
 
 
 (let* ((A (make-array (make-interval '#(4 0)) list))
-       (B (make-array (make-interval '#(0 4)) list))
-       (C (array-inner-product A list list B))) ;; should be no error
-  (test (array-ref C 0 0)
-        "array-inner-product: Attempting to reduce over an empty array: "))
+       (B (make-array (make-interval '#(0 4)) list)))
+  (test (array-inner-product A list list B)
+        "array-inner-product: The width of the first axis of the fourth argument is zero: "))
 
 
 (pp "array-append and array-append! tests")
@@ -6600,7 +6594,7 @@ that computes the componentwise products when we need them, the times are
 
 ;;; Unit tests
 
-(pp 'unit-tests)
+(pp "unit-tests")
 
 (let ((A (make-specialized-array (make-interval '#(5 5 5 5 5) '#(8 8 8 8 8))))
       (B (make-specialized-array (make-interval '#(5 5 5 5 5)))))


### PR DESCRIPTION
generic-arrays.scm:

1.  array-tile: Rationalize error checking.

2.  array-reduce, %%array-reduce: Move error checking from %%array-reduce to caller array-reduce.

3.  %%array-outer-product: Delete error caller information from call to %%array-reduce.

4.  array-outer-product: If the width of the axis that will be reduced is zero, fail eagerly instead of waiting until an element of the result is accessed.

test-arrays:

1.  array-tile: update error messages.

2.  array-inner-product: update tests.

3. Small clean-ups