### PR TITLE
Fix array-extract of specialized arrays

### DIFF
--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -3325,27 +3325,7 @@ OTHER DEALINGS IN THE SOFTWARE.
               (%%array-setter array)))
 
 (define (%%specialized-array-extract array new-domain)
-
-  ;; (%%specialized-array-share array new-domain values)
-
-  ;; We can speed this by calling make-%%array directly,
-  ;; and so avoid a call to %%compose-indexers with values as
-  ;; new-domain->old-domain and avoid the computation of the
-  ;; new indexer, getter, and setter.
-
-  (make-%%array new-domain
-                (if (%%interval-empty? new-domain)
-                    (%%empty-getter new-domain)
-                    (%%array-getter array))
-                (and (%%array-setter array)   ;; If array has no setter, then don't add one to extracted array
-                     (if (%%interval-empty? new-domain)
-                         (%%empty-setter new-domain)
-                         (%%array-setter array)))
-                (%%array-storage-class array)
-                (%%array-body array)
-                (%%array-indexer array)
-                (%%array-safe? array)
-                %%order-unknown))
+  (%%specialized-array-share array new-domain values))
 
 (define (%%array-extract array new-domain)
   (cond ((specialized-array? array)

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -3911,6 +3911,14 @@ OTHER DEALINGS IN THE SOFTWARE.
   (test (mutable-array? B)
         #f))
 
+(let* ((A (make-specialized-array (make-interval '#(4 4))
+                                  generic-storage-class
+                                  #t     ;; mutable?
+                                  #t))   ;; safe?
+       (B (array-extract A (make-interval '#(2 2)))))
+  (test (array-ref B 2 2)
+        "array-getter: domain does not contain multi-index: "))
+
 (do ((i 0 (fx+ i 1)))
     ((fx= i random-tests))
   (let* ((domain (random-interval))


### PR DESCRIPTION
generic-arrays.scm:

1.  %%specialized-array-extract: Remove buggy "optimized" code and call %%specialized-array-share directly to preserve safety of specialized arrays.

test-arrays.scm:

1.  Test that safety is preserved in extracted specialized arrays.