### PR TITLE
Remove bound checks in bulk operations; add more checks where needed

### DIFF
--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -71,7 +71,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 (define-type %%array
-  id: d0995125-4e60-4b86-90a2-3bffbe52bcc4
+  id: f27104f3-7acb-4727-8668-8aa83e8fbf20
   copier: #f
   ;; Part of all arrays
   ;; an interval
@@ -79,9 +79,11 @@ OTHER DEALINGS IN THE SOFTWARE.
   (domain read-only:)
   ;; (lambda (i_0 ... i_n-1) ...) returns a value for (i_0,...,i_n-1) in (array-domain a)
   (getter read-only:)
+  (unsafe-getter read-only:)
   ;; Part of mutable arrays
   ;; (lambda (v i_0 ... i_n-1) ...) sets a value for (i_0,...,i_n-1) in (array-domain a)
   (setter read-write:)
+  (unsafe-setter read-write:)
   ;; Part of specialized arrays
   ;; a storage class
   (storage-class read-only:)
@@ -976,7 +978,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                              identity))))))))
         result))
 
-  (if (%%interval-empty? interval)
+  (if (%%interval-empty? interval) ;; handle (make-interval '#(10000000 10000000 0)) efficiently
       identity
       (generate-code)))
 
@@ -1012,6 +1014,28 @@ OTHER DEALINGS IN THE SOFTWARE.
 (define (%%empty-setter domain)
   (lambda args (apply error "array-setter: Array domain is empty: " domain args)))
 
+(declare (not inline))
+
+(define (%%make-safer-array domain unsafe-getter #!optional (unsafe-setter #f) (checker #f))
+  (let ((getter
+         (%%wrap-getter-in-index-checks domain unsafe-getter))
+        (setter
+         (and unsafe-setter
+              (%%wrap-setter-in-index-and-value-checks domain unsafe-setter checker))))
+    (make-%%array domain
+                  getter
+                  unsafe-getter
+                  setter
+                  unsafe-setter
+                  #f              ; storage-class
+                  #f              ; body
+                  #f              ; indexer
+                  #f              ; safe?
+                  %%order-unknown ; in-order?
+                  )))
+
+(declare (inline))
+
 (define make-array
   (case-lambda
    ((domain getter)
@@ -1020,17 +1044,8 @@ OTHER DEALINGS IN THE SOFTWARE.
           ((not (procedure? getter))
            (error "make-array: The second argument is not a procedure: " domain getter))
           (else
-           (make-%%array domain
-                         (if (%%interval-empty? domain)
-                             (%%empty-getter domain)
-                             getter)
-                         #f              ; no setter
-                         #f              ; storage-class
-                         #f              ; body
-                         #f              ; indexer
-                         #f              ; safe?
-                         %%order-unknown ; in-order?
-                         ))))
+           ;; we're going to add checking that the arguments to the getter are valid
+           (%%make-safer-array domain getter))))
    ((domain getter setter)
     (cond ((not (interval? domain))
            (error "make-array: The first argument is not an interval: " domain getter setter))
@@ -1039,19 +1054,8 @@ OTHER DEALINGS IN THE SOFTWARE.
           ((not (procedure? setter))
            (error "make-array: The third argument is not a procedure: " domain getter setter))
           (else
-           (make-%%array domain
-                         (if (%%interval-empty? domain)
-                             (%%empty-getter domain)
-                             getter)
-                         (if (%%interval-empty? domain)
-                             (%%empty-setter domain)
-                             setter)
-                         #f              ; storage-class
-                         #f              ; body
-                         #f              ; indexer
-                         #f              ; safe?
-                         %%order-unknown ; in-order?
-                         ))))))
+           ;; we're going to add checking that the arguments to getter and setter are valid
+           (%%make-safer-array domain getter setter))))))
 
 (define (array? x)
   (%%array? x))
@@ -1112,6 +1116,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (define (%%array-freeze! A)
   (%%array-setter-set! A #f)
+  (%%array-unsafe-setter-set! A #f)
   A)
 
 (define (array-freeze! A)
@@ -1157,7 +1162,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                       (,ref v i))
                     ;; setter
                     (lambda (v i val)
-                      (,set! v i val) (void))
+                      (,set! v i val))
                     ;; checker
                     ,checker           ;; already expanded
                     ;; maker
@@ -1263,8 +1268,7 @@ OTHER DEALINGS IN THE SOFTWARE.
            (bodyv (vector-ref v  1)))
        (u16vector-set! bodyv index (fxior (fxarithmetic-shift-left val shift)
                                           (fxand (u16vector-ref bodyv index)
-                                                 (fxnot (fxarithmetic-shift-left 1 shift)))))
-       (void)))
+                                                 (fxnot (fxarithmetic-shift-left 1 shift)))))))
    ;; checker
    (lambda (val)
      (and (fixnum? val)
@@ -1310,8 +1314,7 @@ OTHER DEALINGS IN THE SOFTWARE.
             ;; setter
             (lambda (body i obj)
               (,(symbol-concatenate floating-point-prefix 'vector-set!) body (fx* 2 i)         (real-part obj))
-              (,(symbol-concatenate floating-point-prefix 'vector-set!) body (fx+ (fx* 2 i) 1) (imag-part obj))
-              (void))
+              (,(symbol-concatenate floating-point-prefix 'vector-set!) body (fx+ (fx* 2 i) 1) (imag-part obj)))
             ;; checker
             (lambda (obj)
               (and (complex? obj)
@@ -1494,7 +1497,7 @@ OTHER DEALINGS IN THE SOFTWARE.
        (f16->double (u16vector-ref body i)))
      ;; setter
      (lambda (body i obj)
-       (u16vector-set! body i (double->f16 obj)) (void))
+       (u16vector-set! body i (double->f16 obj)))
      ;; checker
      (lambda (obj)
        (flonum? obj))
@@ -2063,6 +2066,115 @@ OTHER DEALINGS IN THE SOFTWARE.
         (else
          (%%array-packed? array))))
 
+(define (%%wrap-getter-in-index-checks domain unsafe-getter)
+  (if (%%interval-empty? domain)
+      (%%empty-getter domain)
+      (case (%%interval-dimension domain)
+        ((0) (lambda ()        ;; we wrap it in a thunk to ensure that it's called with no arguments
+               (unsafe-getter)))
+        ((1)  (lambda (i)
+                (declare (inlining-limit 10000))
+                (cond ((not (exact-integer? i))
+                       (error "array-getter: multi-index component is not an exact integer: " i))
+                      ((not (%%interval-contains-multi-index?-1 domain i))
+                       (error "array-getter: domain does not contain multi-index: "    domain i))
+                      (else
+                       (unsafe-getter i)))))
+        ((2)  (lambda (i j)
+                (declare (inlining-limit 10000))
+                (cond ((not (and (exact-integer? i) (exact-integer? j)))
+                       (error "array-getter: multi-index component is not an exact integer: " i j))
+                      ((not (%%interval-contains-multi-index?-2 domain i j))
+                       (error "array-getter: domain does not contain multi-index: "    domain i j))
+                      (else
+                       (unsafe-getter i j)))))
+        ((3)  (lambda (i j k)
+                (declare (inlining-limit 10000))
+                (cond ((not (and (exact-integer? i) (exact-integer? j) (exact-integer? k)))
+                       (error "array-getter: multi-index component is not an exact integer: " i j k))
+                      ((not (%%interval-contains-multi-index?-3 domain i j k))
+                       (error "array-getter: domain does not contain multi-index: "    domain i j k))
+                      (else
+                       (unsafe-getter i j k)))))
+        ((4)  (lambda (i j k l)
+                (declare (inlining-limit 10000))
+                (cond ((not (and (exact-integer? i) (exact-integer? j) (exact-integer? k) (exact-integer? l)))
+                       (error "array-getter: multi-index component is not an exact integer: " i j k l))
+                      ((not (%%interval-contains-multi-index?-4 domain i j k l))
+                       (error "array-getter: domain does not contain multi-index: "    domain i j k l))
+                      (else
+                       (unsafe-getter i j k l)))))
+        (else (lambda multi-index
+                (cond ((not (%%every (lambda (x) (exact-integer? x)) multi-index))
+                       (apply error "array-getter: multi-index component is not an exact integer: " multi-index))
+                      ((not (fx= (%%interval-dimension domain) (length multi-index)))
+                       (apply error "array-getter: multi-index is not the correct dimension: " domain multi-index))
+                      ((not (%%interval-contains-multi-index?-general domain multi-index))
+                       (apply error "array-getter: domain does not contain multi-index: "    domain multi-index))
+                      (else
+                       (apply unsafe-getter multi-index))))))))
+
+(define (%%wrap-setter-in-index-and-value-checks domain unsafe-setter #!optional (checker #f))
+  (if (%%interval-empty? domain)
+      (%%empty-setter domain)
+      (case (%%interval-dimension domain)
+        ((0)  (lambda (value)
+                (cond ((and checker (not (checker value)))
+                       (error "array-setter: value cannot be stored in body: " value))
+                      (else
+                       (unsafe-setter value) (void)))))
+        ((1)  (lambda (value i)
+                (declare (inlining-limit 10000))
+                (cond ((not (exact-integer? i))
+                       (error "array-setter: multi-index component is not an exact integer: " i))
+                      ((not (%%interval-contains-multi-index?-1 domain i))
+                       (error "array-setter: domain does not contain multi-index: "    domain i))
+                      ((and checker (not (checker value)))
+                       (error "array-setter: value cannot be stored in body: " value))
+                      (else
+                       (unsafe-setter value i) (void)))))
+        ((2)  (lambda (value i j)
+                (declare (inlining-limit 10000))
+                (cond ((not (and (exact-integer? i) (exact-integer? j)))
+                       (error "array-setter: multi-index component is not an exact integer: " i j))
+                      ((not (%%interval-contains-multi-index?-2 domain i j))
+                       (error "array-setter: domain does not contain multi-index: "    domain i j))
+                      ((and checker (not (checker value)))
+                       (error "array-setter: value cannot be stored in body: " value))
+                      (else
+                       (unsafe-setter value i j) (void)))))
+        ((3)  (lambda (value i j k)
+                (declare (inlining-limit 10000))
+                (cond ((not (and (exact-integer? i) (exact-integer? j) (exact-integer? k)))
+                       (error "array-setter: multi-index component is not an exact integer: " i j k))
+                      ((not (%%interval-contains-multi-index?-3 domain i j k))
+                       (error "array-setter: domain does not contain multi-index: "    domain i j k))
+                      ((and checker (not (checker value)))
+                       (error "array-setter: value cannot be stored in body: " value))
+                      (else
+                       (unsafe-setter value i j k) (void)))))
+        ((4)  (lambda (value i j k l)
+                (declare (inlining-limit 10000))
+                (cond ((not (and (exact-integer? i) (exact-integer? j) (exact-integer? k) (exact-integer? l)))
+                       (error "array-setter: multi-index component is not an exact integer: " i j k l))
+                      ((not (%%interval-contains-multi-index?-4 domain i j k l))
+                       (error "array-setter: domain does not contain multi-index: "    domain i j k l))
+                      ((and checker (not (checker value)))
+                       (error "array-setter: value cannot be stored in body: " value))
+                      (else
+                       (unsafe-setter value i j k l) (void)))))
+        (else (lambda (value . multi-index)
+                (cond ((not (%%every (lambda (x) (exact-integer? x)) multi-index))
+                       (apply error "array-setter: multi-index component is not an exact integer: " multi-index))
+                      ((not (fx= (%%interval-dimension domain) (length multi-index)))
+                       (apply error "array-setter: multi-index is not the correct dimension: " domain multi-index))
+                      ((not (%%interval-contains-multi-index?-general domain multi-index))
+                       (apply error "array-setter: domain does not contain multi-index: "    domain multi-index))
+                      ((and checker (not (checker value)))
+                       (error "array-setter: value cannot be stored in body: " value))
+                      (else
+                       (apply unsafe-setter value multi-index) (void))))))))
+
 
 (define (%%finish-specialized-array domain storage-class body indexer mutable? safe? in-order?)
   (let ((storage-class-getter (storage-class-getter storage-class))
@@ -2106,147 +2218,43 @@ OTHER DEALINGS IN THE SOFTWARE.
     (define-macro (expand-setters expr)
       `(expand-storage-class -setter -set! ,expr))
 
-    (let ((getter
-           (cond ((%%interval-empty? domain)
-                  (%%empty-getter domain))
-                 (safe?
-                  (case (%%interval-dimension domain)
-                    ((0)  (lambda ()
-                            (storage-class-getter body (indexer))))
-                    ((1)  (lambda (i)
-                            (declare (inlining-limit 10000))
-                            (cond ((not (exact-integer? i))
-                                   (error "array-getter: multi-index component is not an exact integer: " i))
-                                  ((not (%%interval-contains-multi-index?-1 domain i))
-                                   (error "array-getter: domain does not contain multi-index: "    domain i))
-                                  (else
-                                   (storage-class-getter body (indexer i))))))
-                    ((2)  (lambda (i j)
-                            (declare (inlining-limit 10000))
-                            (cond ((not (and (exact-integer? i)
-                                             (exact-integer? j)))
-                                   (error "array-getter: multi-index component is not an exact integer: " i j))
-                                  ((not (%%interval-contains-multi-index?-2 domain i j))
-                                   (error "array-getter: domain does not contain multi-index: "    domain i j))
-                                  (else
-                                   (storage-class-getter body (indexer i j))))))
-                    ((3)  (lambda (i j k)
-                            (declare (inlining-limit 10000))
-                            (cond ((not (and (exact-integer? i)
-                                             (exact-integer? j)
-                                             (exact-integer? k)))
-                                   (error "array-getter: multi-index component is not an exact integer: " i j k))
-                                  ((not (%%interval-contains-multi-index?-3 domain i j k))
-                                   (error "array-getter: domain does not contain multi-index: "    domain i j k))
-                                  (else
-                                   (storage-class-getter body (indexer i j k))))))
-                    ((4)  (lambda (i j k l)
-                            (declare (inlining-limit 10000))
-                            (cond ((not (and (exact-integer? i)
-                                             (exact-integer? j)
-                                             (exact-integer? k)
-                                             (exact-integer? l)))
-                                   (error "array-getter: multi-index component is not an exact integer: " i j k l))
-                                  ((not (%%interval-contains-multi-index?-4 domain i j k l))
-                                   (error "array-getter: domain does not contain multi-index: "    domain i j k l))
-                                  (else
-                                   (storage-class-getter body (indexer i j k l))))))
-                    (else (lambda multi-index
-                            (cond ((not (%%every (lambda (x) (exact-integer? x)) multi-index))
-                                   (apply error "array-getter: multi-index component is not an exact integer: " multi-index))
-                                  ((not (fx= (%%interval-dimension domain) (length multi-index)))
-                                   (apply error "array-getter: multi-index is not the correct dimension: " domain multi-index))
-                                  ((not (%%interval-contains-multi-index?-general domain multi-index))
-                                   (apply error "array-getter: domain does not contain multi-index: "    domain multi-index))
-                                  (else
-                                   (storage-class-getter body (apply indexer multi-index))))))))
-                 (else
-                  (case (%%interval-dimension domain)
-                    ((0)  (expand-getters (lambda ()          (storage-class-getter body (indexer)))))
-                    ((1)  (expand-getters (lambda (i)         (storage-class-getter body (indexer i)))))
-                    ((2)  (expand-getters (lambda (i j)       (storage-class-getter body (indexer i j)))))
-                    ((3)  (expand-getters (lambda (i j k)     (storage-class-getter body (indexer i j k)))))
-                    ((4)  (expand-getters (lambda (i j k l)   (storage-class-getter body (indexer i j k l)))))
-                    (else (expand-getters (lambda multi-index (storage-class-getter body (apply indexer multi-index)))))))))
-          (setter
-           (and mutable?
-                (cond ((%%interval-empty? domain)
-                       (%%empty-setter domain))
-                      (safe?
-                       (case (%%interval-dimension domain)
-                         ((0)  (lambda (value)
-                                 (cond ((not (checker value))
-                                        (error "array-setter: value cannot be stored in body: " value))
-                                       (else
-                                        (storage-class-setter body (indexer) value)))))
-                         ((1)  (lambda (value i)
-                                 (declare (inlining-limit 10000))
-                                 (cond ((not (exact-integer? i))
-                                        (error "array-setter: multi-index component is not an exact integer: " i))
-                                       ((not (%%interval-contains-multi-index?-1 domain i))
-                                        (error "array-setter: domain does not contain multi-index: "    domain i))
-                                       ((not (checker value))
-                                        (error "array-setter: value cannot be stored in body: " value))
-                                       (else
-                                        (storage-class-setter body (indexer i) value)))))
-                         ((2)  (lambda (value i j)
-                                 (declare (inlining-limit 10000))
-                                 (cond ((not (and (exact-integer? i)
-                                                  (exact-integer? j)))
-                                        (error "array-setter: multi-index component is not an exact integer: " i j))
-                                       ((not (%%interval-contains-multi-index?-2 domain i j))
-                                        (error "array-setter: domain does not contain multi-index: "    domain i j))
-                                       ((not (checker value))
-                                        (error "array-setter: value cannot be stored in body: " value))
-                                       (else
-                                        (storage-class-setter body (indexer i j) value)))))
-                         ((3)  (lambda (value i j k)
-                                 (declare (inlining-limit 10000))
-                                 (cond ((not (and (exact-integer? i)
-                                                  (exact-integer? j)
-                                                  (exact-integer? k)))
-                                        (error "array-setter: multi-index component is not an exact integer: " i j k))
-                                       ((not (%%interval-contains-multi-index?-3 domain i j k))
-                                        (error "array-setter: domain does not contain multi-index: "    domain i j k))
-                                       ((not (checker value))
-                                        (error "array-setter: value cannot be stored in body: " value))
-                                       (else
-                                        (storage-class-setter body (indexer i j k) value)))))
-                         ((4)  (lambda (value i j k l)
-                                 (declare (inlining-limit 10000))
-                                 (cond ((not (and (exact-integer? i)
-                                                  (exact-integer? j)
-                                                  (exact-integer? k)
-                                                  (exact-integer? l)))
-                                        (error "array-setter: multi-index component is not an exact integer: " i j k l))
-                                       ((not (%%interval-contains-multi-index?-4 domain i j k l))
-                                        (error "array-setter: domain does not contain multi-index: "    domain i j k l))
-                                       ((not (checker value))
-                                        (error "array-setter: value cannot be stored in body: " value))
-                                       (else
-                                        (storage-class-setter body (indexer i j k l) value)))))
-                         (else (lambda (value . multi-index)
-                                 (cond ((not (%%every (lambda (x) (exact-integer? x)) multi-index))
-                                        (apply error "array-setter: multi-index component is not an exact integer: " multi-index))
-                                       ((not (fx= (%%interval-dimension domain) (length multi-index)))
-                                        (apply error "array-setter: multi-index is not the correct dimension: " domain multi-index))
-                                       ((not (%%interval-contains-multi-index?-general domain multi-index))
-                                        (apply error "array-setter: domain does not contain multi-index: "    domain multi-index))
-                                       ((not (checker value))
-                                        (error "array-setter: value cannot be stored in body: " value))
-                                       (else
-                                        (storage-class-setter body (apply indexer multi-index) value)))))))
-                      (else
-                       (case (%%interval-dimension domain)
-                         ((0)  (expand-setters (lambda (value)               (storage-class-setter body (indexer)                   value) (void))))
-                         ((1)  (expand-setters (lambda (value i)             (storage-class-setter body (indexer i)                 value) (void))))
-                         ((2)  (expand-setters (lambda (value i j)           (storage-class-setter body (indexer i j)               value) (void))))
-                         ((3)  (expand-setters (lambda (value i j k)         (storage-class-setter body (indexer i j k)             value) (void))))
-                         ((4)  (expand-setters (lambda (value i j k l)       (storage-class-setter body (indexer i j k l)           value) (void))))
-                         (else (expand-setters (lambda (value . multi-index) (storage-class-setter body (apply indexer multi-index) value) (void))))))))))
+    (let* ((unsafe-getter
+            (if (%%interval-empty? domain)
+                (%%empty-getter domain)
+                (case (%%interval-dimension domain)
+                  ((0)  (expand-getters (lambda ()        (storage-class-getter body (indexer)))))
+                  ((1)  (expand-getters (lambda (i)       (storage-class-getter body (indexer i)))))
+                  ((2)  (expand-getters (lambda (i j)     (storage-class-getter body (indexer i j)))))
+                  ((3)  (expand-getters (lambda (i j k)   (storage-class-getter body (indexer i j k)))))
+                  ((4)  (expand-getters (lambda (i j k l) (storage-class-getter body (indexer i j k l)))))
+                  (else
+                   ;; There's not much point in expanding the storage-class-getter considering the
+                   ;; overhead of variable-argument function call, apply, etc.
+                   (lambda multi-index (storage-class-getter body (apply indexer multi-index)))))))
+           (getter
+            (%%wrap-getter-in-index-checks domain unsafe-getter))
+           (unsafe-setter
+            (and mutable?
+                 (if (%%interval-empty? domain)
+                     (%%empty-setter domain)
+                     (case (%%interval-dimension domain)
+                       ((0)  (expand-setters (lambda (value)         (storage-class-setter body (indexer)         value))))
+                       ((1)  (expand-setters (lambda (value i)       (storage-class-setter body (indexer i)       value))))
+                       ((2)  (expand-setters (lambda (value i j)     (storage-class-setter body (indexer i j)     value))))
+                       ((3)  (expand-setters (lambda (value i j k)   (storage-class-setter body (indexer i j k)   value))))
+                       ((4)  (expand-setters (lambda (value i j k l) (storage-class-setter body (indexer i j k l) value))))
+                       ;; There's not much point in expanding the storage-class-setter considering the
+                       ;; overhead of variable-argument function call, apply, etc.
+                       (else (lambda (value . multi-index) (storage-class-setter body (apply indexer multi-index) value)))))))
+
+           (setter
+            (and mutable?
+                 (%%wrap-setter-in-index-and-value-checks domain unsafe-setter checker))))
       (make-%%array domain
                     getter
+                    unsafe-getter
                     setter
+                    unsafe-setter
                     storage-class
                     body
                     indexer
@@ -2651,318 +2659,147 @@ OTHER DEALINGS IN THE SOFTWARE.
     (error (string-append caller "Not all elements of the source can be stored in destination: ")
            destination source item))
 
-  (if (not (%%interval= (%%array-domain source) (%%array-domain destination)))
-      (domain-error))
-  (let ((common-domain (%%array-domain source)))
-    (if (%%interval-empty? common-domain)
-        "Empty arrays"
-        (if (specialized-array? destination)
-            (let* ((destination-storage-class (%%array-storage-class destination))
-                   (destination-indexer       (%%array-indexer destination))
-                   (destination-body          (%%array-body destination))
-                   (destination-setter        (storage-class-setter destination-storage-class))
-                   (destination-checker       (storage-class-checker destination-storage-class)))
-              (if (specialized-array? source)
-                  (let* ((source-storage-class (%%array-storage-class source))
-                         (source-indexer       (%%array-indexer source))
-                         (source-body          (%%array-body source))
-                         (source-getter        (storage-class-getter source-storage-class)))
-                    (if (and (%%array-packed? destination)
-                             (%%array-packed? source))
-                        (let* ((initial-destination-index (%%interval-lower-bounds->list common-domain))
-                               (destination-start         (apply destination-indexer initial-destination-index))
-                               (initial-source-index      (%%interval-lower-bounds->list common-domain))
-                               (source-start              (apply source-indexer initial-source-index))
-                               (source-end                (fx+ source-start (%%interval-volume common-domain))))
-                          (cond ((and (eq? destination-storage-class source-storage-class)
-                                      (storage-class-copier destination-storage-class))
-                                 ((storage-class-copier destination-storage-class)
-                                  destination-body
-                                  destination-start
-                                  source-body
-                                  source-start
-                                  source-end)
-                                 "Block copy")
-                                ((eq? destination-storage-class generic-storage-class)
-                                 (do ((d destination-start (fx+ d 1))
-                                      (s source-start      (fx+ s 1)))
-                                     ((fx= s source-end)
-                                      "In order, no checks needed, generic storage-class")
-                                   (vector-set! destination-body d (source-getter source-body s))))
-                                ((or (eq? destination-storage-class source-storage-class)
-                                     (let ((compatibility-list
-                                            (assq (%%array-storage-class source)
-                                                  %%storage-class-compatibility-alist)))
-                                       (and compatibility-list
-                                            (memq destination-storage-class
-                                                  compatibility-list))))
-                                 ;; No checks needed
-                                 (do ((d destination-start (fx+ d 1))
-                                      (s source-start      (fx+ s 1)))
-                                     ((fx= s source-end)
-                                      "In order, no checks needed")
-                                   (destination-setter destination-body d (source-getter source-body s))))
-                                (else
-                                 ;; Checks needed
-                                 (do ((d destination-start (fx+ d 1))
-                                      (s source-start      (fx+ s 1)))
-                                     ((fx= s source-end)
-                                      "In order, checks needed")
-                                   (let ((item (source-getter source-body s)))
-                                     (if (destination-checker item)
-                                         (destination-setter destination-body d
-                                                             (source-getter source-body s))
-                                         (checker-error item)))))))
+  (cond ((not (%%interval= (%%array-domain source) (%%array-domain destination)))
+         (domain-error))
+        ((%%interval-empty? (%%array-domain source))
+         "Empty arrays")
+        ((and (specialized-array? destination)
+              (specialized-array? source)
+              (%%array-packed? destination)
+              (%%array-packed? source))
+         (let* ((common-domain             (%%array-domain source))
+                (initial-multindex         (%%interval-lower-bounds->list common-domain))
+                (destination-body          (%%array-body destination))
+                (destination-storage-class (%%array-storage-class destination))
+                (destination-start         (apply (%%array-indexer destination) initial-multindex))
+                (source-body               (%%array-body source))
+                (source-storage-class      (%%array-storage-class source))
+                (source-start              (apply (%%array-indexer source) initial-multindex))
+                (source-end                (fx+ source-start (%%interval-volume common-domain))))
+           (if (and (eq? destination-storage-class source-storage-class)
+                    (storage-class-copier destination-storage-class))
+               (begin
+                 ((storage-class-copier destination-storage-class)
+                  destination-body
+                  destination-start
+                  source-body
+                  source-start
+                  source-end)
+                 "Block copy")
+               (let* ((destination-setter  (storage-class-setter destination-storage-class))
+                      (destination-checker (storage-class-checker destination-storage-class))
+                      (source-getter       (storage-class-getter source-storage-class)))
+                 (cond ((eq? destination-storage-class generic-storage-class)
+                        (do ((d destination-start (fx+ d 1))
+                             (s source-start      (fx+ s 1)))
+                            ((fx= s source-end)
+                             "In order, no checks needed, generic storage-class")
+                          (vector-set! destination-body d (source-getter source-body s))))
+                       ((or (eq? destination-storage-class source-storage-class)
+                            (let ((compatibility-list
+                                   (assq source-storage-class %%storage-class-compatibility-alist)))
+                              (and compatibility-list
+                                   (memq destination-storage-class compatibility-list))))
+                        ;; No checks needed
+                        (do ((d destination-start (fx+ d 1))
+                             (s source-start      (fx+ s 1)))
+                            ((fx= s source-end)
+                             "In order, no checks needed")
+                          (destination-setter destination-body d (source-getter source-body s))))
+                       (else
+                        ;; Checks needed
+                        (do ((d destination-start (fx+ d 1))
+                             (s source-start      (fx+ s 1)))
+                            ((fx= s source-end)
+                             "In order, checks needed")
+                          (let ((item (source-getter source-body s)))
+                            (if (destination-checker item)
+                                (destination-setter destination-body d
+                                                    (source-getter source-body s))
+                                (checker-error item))))))))))
+        ((or (not (specialized-array? destination))
+             (let ((destination-storage-class (%%array-storage-class destination)))
+               (or (eq? destination-storage-class generic-storage-class)
+                   (and (specialized-array? source)
+                        (let ((source-storage-class (%%array-storage-class source)))
+                          (or (eq? destination-storage-class source-storage-class)
+                              (let ((compatibility-list
+                                     (assq source-storage-class %%storage-class-compatibility-alist)))
+                                (and compatibility-list
+                                     (memq destination-storage-class compatibility-list)))))))))
+         ;; either no checks are possible (not a specialized array), or no checks are needed
+         (let ((common-domain (%%array-domain source))
+               (unsafe-getter (%%array-unsafe-getter source))
+               (unsafe-setter (%%array-unsafe-setter destination)))
+           (%%interval-for-each
+            (case (%%interval-dimension common-domain)
+              ((0)
+               (lambda ()        (unsafe-setter (unsafe-getter))))
+              ((1)
+               (lambda (i)       (unsafe-setter (unsafe-getter i)       i)))
+              ((2)
+               (lambda (i j)     (unsafe-setter (unsafe-getter i j)     i j)))
+              ((3)
+               (lambda (i j k)   (unsafe-setter (unsafe-getter i j k)   i j k)))
+              ((4)
+               (lambda (i j k l) (unsafe-setter (unsafe-getter i j k l) i j k l)))
+              (else
+               (lambda args
+                 (apply unsafe-setter (apply unsafe-getter args) args))))
+            common-domain)
+           "Out of order, no checks"))
+        (else
+         ;; destination is a specialized array, and checks are needed.
+         (let ((common-domain       (%%array-domain source))
+               (unsafe-getter       (%%array-unsafe-getter source))
+               (unsafe-setter       (%%array-unsafe-setter destination))
+               (destination-checker (storage-class-checker (%%array-storage-class destination))))
+           (begin
+             (%%interval-for-each
+              (case (%%interval-dimension common-domain)
+                ((0)
+                 (lambda ()
+                   (let ((item (unsafe-getter)))
+                     (if (destination-checker item)
+                         (unsafe-setter item)
+                         (checker-error item)))))
+                ((1)
+                 (lambda (i)
+                   (let ((item (unsafe-getter i)))
+                     (if (destination-checker item)
+                         (unsafe-setter item i)
+                         (checker-error item)))))
+                ((2)
+                 (lambda (i j)
+                   (let ((item (unsafe-getter i j)))
+                     (if (destination-checker item)
+                         (unsafe-setter item i j)
+                         (checker-error item)))))
+                ((3)
+                 (lambda (i j k)
+                   (let ((item (unsafe-getter i j k)))
+                     (if (destination-checker item)
+                         (unsafe-setter item i j k)
+                         (checker-error item)))))
+                ((4)
+                 (lambda (i j k l)
+                   (let ((item (unsafe-getter i j k l)))
+                     (if (destination-checker item)
+                         (unsafe-setter item i j k l)
+                         (checker-error item)))))
+                (else
+                 (lambda args
+                   (let ((item (apply unsafe-getter args)))
+                     (if (destination-checker item)
+                         (apply unsafe-setter item args)
+                         (checker-error item))))))
+              common-domain)
+             "Out of order, checks"))))
 
-                        ;; Source and destination are not both packed, so we can't step
-                        ;; through their bodies with step 1
-
-                        (if (eq? destination-storage-class generic-storage-class)
-                            ;; Out of order, no checks needed, generic-storage-class
-                            (begin
-                              (%%interval-for-each
-                               (case (%%interval-dimension common-domain)
-                                 ;; Arrays of dimension zero, which contain only one
-                                 ;; element, are always packed, so there is no zero case.
-                                 ((1)
-                                  (lambda (i)
-                                    (vector-set! destination-body
-                                                 (destination-indexer i)
-                                                 (source-getter source-body (source-indexer i)))))
-                                 ((2)
-                                  (lambda (i j)
-                                    (vector-set! destination-body
-                                                 (destination-indexer i j)
-                                                 (source-getter source-body (source-indexer i j)))))
-                                 ((3)
-                                  (lambda (i j k)
-                                    (vector-set! destination-body
-                                                 (destination-indexer i j k)
-                                                 (source-getter source-body (source-indexer i j k)))))
-                                 ((4)
-                                  (lambda (i j k l)
-                                    (vector-set! destination-body
-                                                 (destination-indexer i j k l)
-                                                 (source-getter source-body (source-indexer i j k l)))))
-                                 (else
-                                  (lambda args
-                                    (vector-set! destination-body
-                                                 (apply destination-indexer args)
-                                                 (source-getter source-body (apply source-indexer args))))))
-                               common-domain)
-                              "Out of order, no checks needed, generic-storage-class")
-                            ;; destination-storage-class is not generic-storage-class,
-                            ;; but checks may still not be needed
-                            (if (or (eq? destination-storage-class generic-storage-class)
-                                    (let ((compatibility-list
-                                           (assq (%%array-storage-class source)
-                                                 %%storage-class-compatibility-alist)))
-                                      (and compatibility-list
-                                           (memq destination-storage-class
-                                                 compatibility-list))))
-                                ;; No checks needed
-                                (begin
-                                  (%%interval-for-each
-                                   (case (%%interval-dimension common-domain)
-                                     ;; Arrays of dimension zero, which contain only one
-                                     ;; element, are always packed, so there is no zero case.
-                                     ((1)
-                                      (lambda (i)
-                                        (destination-setter destination-body
-                                                            (destination-indexer i)
-                                                            (source-getter source-body (source-indexer i)))))
-                                     ((2)
-                                      (lambda (i j)
-                                        (destination-setter destination-body
-                                                            (destination-indexer i j)
-                                                            (source-getter source-body (source-indexer i j)))))
-                                     ((3)
-                                      (lambda (i j k)
-                                        (destination-setter destination-body
-                                                            (destination-indexer i j k)
-                                                            (source-getter source-body (source-indexer i j k)))))
-                                     ((4)
-                                      (lambda (i j k l)
-                                        (destination-setter destination-body
-                                                            (destination-indexer i j k l)
-                                                            (source-getter source-body (source-indexer i j k l)))))
-                                     (else
-                                      (lambda args
-                                        (destination-setter destination-body
-                                                            (apply destination-indexer args)
-                                                            (source-getter source-body (apply source-indexer args))))))
-                                   common-domain)
-                                  "Out of order, no checks needed")
-                                ;; Checks needed
-                                (begin
-                                  (%%interval-for-each
-                                   (case (%%interval-dimension common-domain)
-                                     ;; Arrays of dimension zero, which contain only one
-                                     ;; element, are always packed, so there is no zero case.
-                                     ((1)
-                                      (lambda (i)
-                                        (let ((item (source-getter source-body (source-indexer i))))
-                                          (if (destination-checker item)
-                                              (destination-setter destination-body
-                                                                  (destination-indexer i)
-                                                                  item)
-                                              (checker-error item)))))
-                                     ((2)
-                                      (lambda (i j)
-                                        (let ((item (source-getter source-body (source-indexer i j))))
-                                          (if (destination-checker item)
-                                              (destination-setter destination-body
-                                                                  (destination-indexer i j)
-                                                                  item)
-                                              (checker-error item)))))
-                                     ((3)
-                                      (lambda (i j k)
-                                        (let ((item (source-getter source-body (source-indexer i j k))))
-                                          (if (destination-checker item)
-                                              (destination-setter destination-body
-                                                                  (destination-indexer i j k)
-                                                                  item)
-                                              (checker-error item)))))
-                                     ((4)
-                                      (lambda (i j k l)
-                                        (let ((item (source-getter source-body (source-indexer i j k l))))
-                                          (if (destination-checker item)
-                                              (destination-setter destination-body
-                                                                  (destination-indexer i j k l)
-                                                                  item)
-                                              (checker-error item)))))
-                                     (else
-                                      (lambda args
-                                        (let ((item (source-getter source-body (apply source-indexer args))))
-                                          (if (destination-checker item)
-                                              (destination-setter destination-body
-                                                                  (apply destination-indexer args)
-                                                                  item)
-                                              (checker-error item))))))
-                                   common-domain)
-                                  "Out of order, checks needed")))))
-                  ;; Source is not a specialized array
-                  (if (eq? destination-storage-class generic-storage-class)
-                      ;; checks are not needed, setter is vector-set!
-                      (let ((source-getter (%%array-getter source)))
-                        (%%interval-for-each
-                         (case (%%interval-dimension common-domain)
-                           ((0)
-                            (lambda ()
-                              (vector-set! destination-body
-                                           (destination-indexer)
-                                           (source-getter))))
-                           ((1)
-                            (lambda (i)
-                              (vector-set! destination-body
-                                           (destination-indexer i)
-                                           (source-getter i))))
-                           ((2)
-                            (lambda (i j)
-                              (vector-set! destination-body
-                                           (destination-indexer i j)
-                                           (source-getter i j))))
-                           ((3)
-                            (lambda (i j k)
-                              (vector-set! destination-body
-                                           (destination-indexer i j k)
-                                           (source-getter i j k))))
-                           ((4)
-                            (lambda (i j k l)
-                              (vector-set! destination-body
-                                           (destination-indexer i j k l)
-                                           (source-getter i j k l))))
-                           (else
-                            (lambda args
-                              (vector-set! destination-body
-                                           (apply destination-indexer args)
-                                           (apply source-getter args)))))
-                         common-domain)
-                        "Checks not needed, source not specialized, generic-storage-class")
-                      ;; destination-storage-class is not generic-storage-class, so
-                      ;; checks are needed and we call destination-setter instead of
-                      ;; vector-set!
-                      (let ((source-getter (%%array-getter source)))
-                        (%%interval-for-each
-                         (case (%%interval-dimension common-domain)
-                           ((0)
-                            (lambda ()
-                              (let ((item (source-getter)))
-                                (if (destination-checker item)
-                                    (destination-setter destination-body
-                                                        (destination-indexer)
-                                                        item)
-                                    (checker-error item)))))
-                           ((1)
-                            (lambda (i)
-                              (let ((item (source-getter i)))
-                                (if (destination-checker item)
-                                    (destination-setter destination-body
-                                                        (destination-indexer i)
-                                                        item)
-                                    (checker-error item)))))
-                           ((2)
-                            (lambda (i j)
-                              (let ((item (source-getter i j)))
-                                (if (destination-checker item)
-                                    (destination-setter destination-body
-                                                        (destination-indexer i j)
-                                                        item)
-                                    (checker-error item)))))
-                           ((3)
-                            (lambda (i j k)
-                              (let ((item (source-getter i j k)))
-                                (if (destination-checker item)
-                                    (destination-setter destination-body
-                                                        (destination-indexer i j k)
-                                                        item)
-                                    (checker-error item)))))
-                           ((4)
-                            (lambda (i j k l)
-                              (let ((item (source-getter i j k l)))
-                                (if (destination-checker item)
-                                    (destination-setter destination-body
-                                                        (destination-indexer i j k l)
-                                                        item)
-                                    (checker-error item)))))
-                           (else
-                            (lambda args
-                              (let ((item (apply source-getter args)))
-                                (if (destination-checker item)
-                                    (destination-setter destination-body
-                                                        (apply destination-indexer args)
-                                                        item)
-                                    (checker-error item))))))
-                         common-domain)
-                        "Checks needed, source not specialized"))))
-            ;; destination is not a specialized array, so checks,
-            ;; if any, are built into the setter.
-            (let ((setter
-                   (%%array-setter destination))
-                  (getter
-                   (%%array-getter source)))
-              (%%interval-for-each
-               (case (%%interval-dimension common-domain)
-                 ((0) (lambda ()
-                        (setter (getter))))
-                 ((1) (lambda (i)
-                        (setter (getter i)i)))
-                 ((2) (lambda (i j)
-                        (setter (getter i j) i j)))
-                 ((3) (lambda (i j k)
-                        (setter (getter i j k) i j k)))
-                 ((4) (lambda (i j k l)
-                        (setter (getter i j k l) i j k l)))
-                 (else
-                  (lambda multi-index
-                    (apply setter
-                           (apply getter multi-index)
-                           multi-index))))
-               common-domain)
-              "Destination not specialized array"))))
   ;; %%move-array-elements returns a string that designates
   ;; the copying method it used.
   ;; Calling functions should return something useful.
+
   )
 
 ;;;
@@ -3238,13 +3075,13 @@ OTHER DEALINGS IN THE SOFTWARE.
                                     new-domain->old-domain))))
 
 (define (%%immutable-array-extract array new-domain)
-  (make-array new-domain
-              (%%array-getter array)))
+  (%%make-safer-array new-domain
+                      (%%array-unsafe-getter array)))
 
 (define (%%mutable-array-extract array new-domain)
-  (make-array new-domain
-              (%%array-getter array)
-              (%%array-setter array)))
+  (%%make-safer-array new-domain
+                      (%%array-unsafe-getter array)
+                      (%%array-unsafe-setter array)))
 
 (define (%%specialized-array-extract array new-domain)
   (%%specialized-array-share array new-domain values))
@@ -3377,7 +3214,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                                                         (vector-map (lambda (slice-offsets i) (vector-ref slice-offsets (fx+ i 1))) offsets i))))
                                (%%array-extract A subdomain))))))
 
-                     (%%make-safe-immutable-array result-domain (generate-result) "array-tile: ")))))))))
+                     (%%make-safer-array result-domain (generate-result))))))))))
 
 (define (%%getter-translate getter translation)
   (case (vector-length translation)
@@ -3444,12 +3281,12 @@ OTHER DEALINGS IN THE SOFTWARE.
                                     (%%getter-translate values translation)
                                     (%%array-in-order? array)))
         ((mutable-array? array)
-         (make-array (%%interval-translate (%%array-domain array) translation)
-                     (%%getter-translate (%%array-getter array) translation)
-                     (%%setter-translate (%%array-setter array) translation)))
+         (%%make-safer-array (%%interval-translate (%%array-domain array) translation)
+                             (%%getter-translate (%%array-unsafe-getter array) translation)
+                             (%%setter-translate (%%array-unsafe-setter array) translation)))
         (else
-         (make-array (%%interval-translate (%%array-domain array) translation)
-                     (%%getter-translate (%%array-getter array) translation)))))
+         (%%make-safer-array (%%interval-translate (%%array-domain array) translation)
+                             (%%getter-translate (%%array-unsafe-getter array) translation)))))
 
 (define (array-translate array translation)
   (cond ((not (array? array))
@@ -3521,12 +3358,12 @@ OTHER DEALINGS IN THE SOFTWARE.
                                     (%%interval-permute (%%array-domain array) permutation)
                                     (%%getter-permute values permutation)))
         ((mutable-array? array)
-         (make-array (%%interval-permute (%%array-domain array) permutation)
-                     (%%getter-permute (%%array-getter array) permutation)
-                     (%%setter-permute (%%array-setter array) permutation)))
+         (%%make-safer-array (%%interval-permute (%%array-domain array) permutation)
+                             (%%getter-permute (%%array-unsafe-getter array) permutation)
+                             (%%setter-permute (%%array-unsafe-setter array) permutation)))
         (else
-         (make-array (%%interval-permute (%%array-domain array) permutation)
-                     (%%getter-permute (%%array-getter array) permutation)))))
+         (%%make-safer-array (%%interval-permute (%%array-domain array) permutation)
+                             (%%getter-permute (%%array-unsafe-getter array) permutation)))))
 
 (define (array-permute array permutation)
   (cond ((not (array? array))
@@ -3621,12 +3458,12 @@ OTHER DEALINGS IN THE SOFTWARE.
                                     (%%array-domain array)
                                     (%%getter-reverse values flip? (%%array-domain array))))
         ((mutable-array? array)
-         (make-array (%%array-domain array)
-                     (%%getter-reverse (%%array-getter array) flip? (%%array-domain array))
-                     (%%setter-reverse (%%array-setter array) flip? (%%array-domain array))))
+         (%%make-safer-array (%%array-domain array)
+                             (%%getter-reverse (%%array-unsafe-getter array) flip? (%%array-domain array))
+                             (%%setter-reverse (%%array-unsafe-setter array) flip? (%%array-domain array))))
         (else
-         (make-array (%%array-domain array)
-                     (%%getter-reverse (%%array-getter array) flip? (%%array-domain array))))))
+         (%%make-safer-array (%%array-domain array)
+                             (%%getter-reverse (%%array-unsafe-getter array) flip? (%%array-domain array))))))
 
 (define %%vector-of-trues
   '#(#()
@@ -3750,13 +3587,13 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 (define (%%immutable-array-sample array scales)
-  (make-array (%%interval-scale (%%array-domain array) scales)
-              (%%getter-sample (%%array-getter array) scales (%%array-domain array))))
+  (%%make-safer-array (%%interval-scale (%%array-domain array) scales)
+                      (%%getter-sample (%%array-unsafe-getter array) scales (%%array-domain array))))
 
 (define (%%mutable-array-sample array scales)
-  (make-array (%%interval-scale (%%array-domain array) scales)
-              (%%getter-sample (%%array-getter array) scales (%%array-domain array))
-              (%%setter-sample (%%array-setter array) scales (%%array-domain array))))
+  (%%make-safer-array (%%interval-scale (%%array-domain array) scales)
+                      (%%getter-sample (%%array-unsafe-getter array) scales (%%array-domain array))
+                      (%%setter-sample (%%array-unsafe-setter array) scales (%%array-domain array))))
 
 (define (%%specialized-array-sample array scales)
   (%%specialized-array-share array
@@ -3784,12 +3621,12 @@ OTHER DEALINGS IN THE SOFTWARE.
 (define (%%array-outer-product combiner A B)
   (let* ((D_A            (%%array-domain A))
          (D_B            (%%array-domain B))
-         (A_             (%%array-getter A))
-         (B_             (%%array-getter B))
+         (A_             (%%array-unsafe-getter A))
+         (B_             (%%array-unsafe-getter B))
          (dim_A          (%%interval-dimension D_A))
          (dim_B          (%%interval-dimension D_B))
          (result-domain  (%%interval-cartesian-product (list D_A D_B)))
-         (result-getter
+         (unsafe-result-getter
           (case dim_A
             ((0)
              (case dim_B
@@ -3865,7 +3702,7 @@ OTHER DEALINGS IN THE SOFTWARE.
              (lambda args
                (combiner (apply A_ (take args dim_A))
                          (apply B_ (drop args dim_A))))))))
-    (make-array result-domain result-getter)))
+    (%%make-safer-array result-domain unsafe-result-getter)))
 
 (define (array-outer-product combiner array1 array2)
   (cond ((not (array? array1))
@@ -3877,174 +3714,122 @@ OTHER DEALINGS IN THE SOFTWARE.
         (else
          (%%array-outer-product combiner array1 array2))))
 
-(define (%%make-safe-immutable-array domain getter caller)
-  (make-array
-   domain
-   (case (%%interval-dimension domain)
-     ((0) (lambda ()
-            (getter)))
-     ((1) (lambda (i)
-            (cond ((not (exact-integer? i))
-                   (error (string-append caller "multi-index component is not an exact integer: ") i))
-                  ((not (%%interval-contains-multi-index?-1 domain i))
-                   (error (string-append caller "domain does not contain multi-index: ") domain i))
-                  (else
-                   (getter i)))))
-     ((2) (lambda (i j)
-            (cond ((not (and (exact-integer? i)
-                             (exact-integer? j)))
-                   (error (string-append caller "multi-index component is not an exact integer: ") i j))
-                  ((not (%%interval-contains-multi-index?-2 domain i j))
-                   (error (string-append caller "domain does not contain multi-index: ") domain i j))
-                  (else
-                   (getter i j)))))
-     ((3) (lambda (i j k)
-            (cond ((not (and (exact-integer? i)
-                             (exact-integer? j)
-                             (exact-integer? k)))
-                   (error (string-append caller "multi-index component is not an exact integer: ") i j k))
-                  ((not (%%interval-contains-multi-index?-3 domain i j k))
-                   (error (string-append caller "domain does not contain multi-index: ") domain i j k))
-                  (else
-                   (getter i j k)))))
-     ((4) (lambda (i j k l)
-            (cond ((not (and (exact-integer? i)
-                             (exact-integer? j)
-                             (exact-integer? k)
-                             (exact-integer? l)))
-                   (error (string-append caller "multi-index component is not an exact integer: ") i j k l))
-                  ((not (%%interval-contains-multi-index?-4 domain i j k l))
-                   (error (string-append caller "domain does not contain multi-index: ") domain i j k l))
-                  (else
-                   (getter i j k l)))))
-     (else (lambda multi-index
-             (cond ((not (%%every exact-integer? multi-index))
-                    (apply error (string-append caller "multi-index component is not an exact integer: ") multi-index))
-                   ((not (= (length multi-index) (%%interval-dimension domain)))
-                    (apply error (string-append caller "multi-index is not the correct dimension: ") domain multi-index))
-                   ((not (%%interval-contains-multi-index?-general domain multi-index))
-                    (apply error (string-append caller "domain does not contain multi-index: ") domain multi-index))
-                   (else
-                    (apply getter multi-index))))))))
-
 (define (%%immutable-array-curry array right-dimension)
   (call-with-values
       (lambda () (%%interval-projections (%%array-domain array) right-dimension))
     (lambda (left-interval right-interval)
-      (let ((getter (%%array-getter array)))
-        (%%make-safe-immutable-array
+      (let ((unsafe-getter (%%array-unsafe-getter array)))
+        (%%make-safer-array
          left-interval
          (case (%%interval-dimension left-interval)
            ((0)  (case (%%interval-dimension right-interval)
-                   ((0)  (lambda ()        (make-array right-interval (lambda ()          (getter)))))
-                   ((1)  (lambda ()        (make-array right-interval (lambda (i)         (getter i)))))
-                   ((2)  (lambda ()        (make-array right-interval (lambda (i j)       (getter i j)))))
-                   ((3)  (lambda ()        (make-array right-interval (lambda (i j k)     (getter i j k)))))
-                   ((4)  (lambda ()        (make-array right-interval (lambda (i j k l)   (getter i j k l)))))
-                   (else (lambda ()        (make-array right-interval (lambda multi-index (apply getter multi-index)))))))
+                   ((0)  (lambda ()        (%%make-safer-array right-interval (lambda ()          (unsafe-getter)))))
+                   ((1)  (lambda ()        (%%make-safer-array right-interval (lambda (i)         (unsafe-getter i)))))
+                   ((2)  (lambda ()        (%%make-safer-array right-interval (lambda (i j)       (unsafe-getter i j)))))
+                   ((3)  (lambda ()        (%%make-safer-array right-interval (lambda (i j k)     (unsafe-getter i j k)))))
+                   ((4)  (lambda ()        (%%make-safer-array right-interval (lambda (i j k l)   (unsafe-getter i j k l)))))
+                   (else (lambda ()        (%%make-safer-array right-interval (lambda multi-index (apply unsafe-getter multi-index)))))))
            ((1)  (case (%%interval-dimension right-interval)
-                   ((0)  (lambda (i)       (make-array right-interval (lambda ()          (getter i)))))
-                   ((1)  (lambda (i)       (make-array right-interval (lambda (j)         (getter i j)))))
-                   ((2)  (lambda (i)       (make-array right-interval (lambda (j k)       (getter i j k)))))
-                   ((3)  (lambda (i)       (make-array right-interval (lambda (j k l)     (getter i j k l)))))
-                   (else (lambda (i)       (make-array right-interval (lambda multi-index (apply getter i multi-index)))))))
+                   ((0)  (lambda (i)       (%%make-safer-array right-interval (lambda ()          (unsafe-getter i)))))
+                   ((1)  (lambda (i)       (%%make-safer-array right-interval (lambda (j)         (unsafe-getter i j)))))
+                   ((2)  (lambda (i)       (%%make-safer-array right-interval (lambda (j k)       (unsafe-getter i j k)))))
+                   ((3)  (lambda (i)       (%%make-safer-array right-interval (lambda (j k l)     (unsafe-getter i j k l)))))
+                   (else (lambda (i)       (%%make-safer-array right-interval (lambda multi-index (apply unsafe-getter i multi-index)))))))
            ((2)  (case (%%interval-dimension right-interval)
-                   ((0)  (lambda (i j)     (make-array right-interval (lambda ( )         (getter i j)))))
-                   ((1)  (lambda (i j)     (make-array right-interval (lambda (  k)       (getter i j k)))))
-                   ((2)  (lambda (i j)     (make-array right-interval (lambda (  k l)     (getter i j k l)))))
-                   (else (lambda (i j)     (make-array right-interval (lambda multi-index (apply getter i j multi-index)))))))
+                   ((0)  (lambda (i j)     (%%make-safer-array right-interval (lambda ( )         (unsafe-getter i j)))))
+                   ((1)  (lambda (i j)     (%%make-safer-array right-interval (lambda (  k)       (unsafe-getter i j k)))))
+                   ((2)  (lambda (i j)     (%%make-safer-array right-interval (lambda (  k l)     (unsafe-getter i j k l)))))
+                   (else (lambda (i j)     (%%make-safer-array right-interval (lambda multi-index (apply unsafe-getter i j multi-index)))))))
            ((3)  (case (%%interval-dimension right-interval)
-                   ((0)  (lambda (i j k)   (make-array right-interval (lambda (   )       (getter i j k)))))
-                   ((1)  (lambda (i j k)   (make-array right-interval (lambda (    l)     (getter i j k l)))))
-                   (else (lambda (i j k)   (make-array right-interval (lambda multi-index (apply getter i j k multi-index)))))))
+                   ((0)  (lambda (i j k)   (%%make-safer-array right-interval (lambda (   )       (unsafe-getter i j k)))))
+                   ((1)  (lambda (i j k)   (%%make-safer-array right-interval (lambda (    l)     (unsafe-getter i j k l)))))
+                   (else (lambda (i j k)   (%%make-safer-array right-interval (lambda multi-index (apply unsafe-getter i j k multi-index)))))))
            ((4)  (case (%%interval-dimension right-interval)
-                   ((0)  (lambda (i j k l) (make-array right-interval (lambda (     )     (getter i j k l)))))
-                   (else (lambda (i j k l) (make-array right-interval (lambda multi-index (apply getter i j k l multi-index)))))))
+                   ((0)  (lambda (i j k l) (%%make-safer-array right-interval (lambda (     )     (unsafe-getter i j k l)))))
+                   (else (lambda (i j k l) (%%make-safer-array right-interval (lambda multi-index (apply unsafe-getter i j k l multi-index)))))))
            (else (lambda left-multi-index
-                   (make-array right-interval
-                               (lambda right-multi-index
-                                 (apply getter (append left-multi-index right-multi-index)))))))
-         "array-curry: ")))))
+                   (%%make-safer-array right-interval
+                                       (lambda right-multi-index
+                                         (apply unsafe-getter (append left-multi-index right-multi-index))))))))))))
 
 (define (%%mutable-array-curry array right-dimension)
   (call-with-values
       (lambda () (%%interval-projections (%%array-domain array) right-dimension))
     (lambda (left-interval right-interval)
-      (let ((getter (%%array-getter array))
-            (setter (%%array-setter   array)))
-        (%%make-safe-immutable-array
+      (let ((unsafe-getter (%%array-unsafe-getter array))
+            (unsafe-setter (%%array-unsafe-setter   array)))
+        (%%make-safer-array
          left-interval
          (case (%%interval-dimension left-interval)
            ((0)  (case (%%interval-dimension right-interval)
-                   ((0)  (lambda ()        (make-array right-interval
-                                                       (lambda ( )       (getter  ))
-                                                       (lambda (v)       (setter v)))))
-                   ((1)  (lambda ()        (make-array right-interval
-                                                       (lambda (  i)     (getter   i))
-                                                       (lambda (v i)     (setter v i)))))
-                   ((2)  (lambda ()        (make-array right-interval
-                                                       (lambda (  i j)   (getter   i j))
-                                                       (lambda (v i j)   (setter v i j)))))
-                   ((3)  (lambda ()        (make-array right-interval
-                                                       (lambda (  i j k) (getter   i j k))
-                                                       (lambda (v i j k) (setter v i j k)))))
-                   ((4)  (lambda ()        (make-array right-interval
-                                                       (lambda (  i j k l) (getter   i j k l))
-                                                       (lambda (v i j k l) (setter v i j k l)))))
-                   (else (lambda ()        (make-array right-interval
-                                                       (lambda      multi-index  (apply getter           multi-index))
-                                                       (lambda (v . multi-index) (apply setter v         multi-index)))))))
+                   ((0)  (lambda ()        (%%make-safer-array right-interval
+                                                               (lambda ( )       (unsafe-getter  ))
+                                                               (lambda (v)       (unsafe-setter v)))))
+                   ((1)  (lambda ()        (%%make-safer-array right-interval
+                                                               (lambda (  i)     (unsafe-getter   i))
+                                                               (lambda (v i)     (unsafe-setter v i)))))
+                   ((2)  (lambda ()        (%%make-safer-array right-interval
+                                                               (lambda (  i j)   (unsafe-getter   i j))
+                                                               (lambda (v i j)   (unsafe-setter v i j)))))
+                   ((3)  (lambda ()        (%%make-safer-array right-interval
+                                                               (lambda (  i j k) (unsafe-getter   i j k))
+                                                               (lambda (v i j k) (unsafe-setter v i j k)))))
+                   ((4)  (lambda ()        (%%make-safer-array right-interval
+                                                               (lambda (  i j k l) (unsafe-getter   i j k l))
+                                                               (lambda (v i j k l) (unsafe-setter v i j k l)))))
+                   (else (lambda ()        (%%make-safer-array right-interval
+                                                               (lambda      multi-index  (apply unsafe-getter           multi-index))
+                                                               (lambda (v . multi-index) (apply unsafe-setter v         multi-index)))))))
            ((1)  (case (%%interval-dimension right-interval)
-                   ((0)  (lambda (i)       (make-array right-interval
-                                                       (lambda ( )       (getter   i))
-                                                       (lambda (v)       (setter v i)))))
-                   ((1)  (lambda (i)       (make-array right-interval
-                                                       (lambda (  j)     (getter   i j))
-                                                       (lambda (v j)     (setter v i j)))))
-                   ((2)  (lambda (i)       (make-array right-interval
-                                                       (lambda (  j k)   (getter   i j k))
-                                                       (lambda (v j k)   (setter v i j k)))))
-                   ((3)  (lambda (i)       (make-array right-interval
-                                                       (lambda (  j k l) (getter   i j k l))
-                                                       (lambda (v j k l) (setter v i j k l)))))
-                   (else (lambda (i)       (make-array right-interval
-                                                       (lambda      multi-index  (apply getter   i       multi-index))
-                                                       (lambda (v . multi-index) (apply setter v i       multi-index)))))))
+                   ((0)  (lambda (i)       (%%make-safer-array right-interval
+                                                               (lambda ( )       (unsafe-getter   i))
+                                                               (lambda (v)       (unsafe-setter v i)))))
+                   ((1)  (lambda (i)       (%%make-safer-array right-interval
+                                                               (lambda (  j)     (unsafe-getter   i j))
+                                                               (lambda (v j)     (unsafe-setter v i j)))))
+                   ((2)  (lambda (i)       (%%make-safer-array right-interval
+                                                               (lambda (  j k)   (unsafe-getter   i j k))
+                                                               (lambda (v j k)   (unsafe-setter v i j k)))))
+                   ((3)  (lambda (i)       (%%make-safer-array right-interval
+                                                               (lambda (  j k l) (unsafe-getter   i j k l))
+                                                               (lambda (v j k l) (unsafe-setter v i j k l)))))
+                   (else (lambda (i)       (%%make-safer-array right-interval
+                                                               (lambda      multi-index  (apply unsafe-getter   i       multi-index))
+                                                               (lambda (v . multi-index) (apply unsafe-setter v i       multi-index)))))))
            ((2)  (case (%%interval-dimension right-interval)
-                   ((0)  (lambda (i j)     (make-array right-interval
-                                                       (lambda (   )     (getter   i j))
-                                                       (lambda (v  )     (setter v i j)))))
-                   ((1)  (lambda (i j)     (make-array right-interval
-                                                       (lambda (    k)   (getter   i j k))
-                                                       (lambda (v   k)   (setter v i j k)))))
-                   ((2)  (lambda (i j)     (make-array right-interval
-                                                       (lambda (    k l) (getter   i j k l))
-                                                       (lambda (v   k l) (setter v i j k l)))))
-                   (else (lambda (i j)     (make-array right-interval
-                                                       (lambda      multi-index  (apply getter   i j     multi-index))
-                                                       (lambda (v . multi-index) (apply setter v i j     multi-index)))))))
+                   ((0)  (lambda (i j)     (%%make-safer-array right-interval
+                                                               (lambda (   )     (unsafe-getter   i j))
+                                                               (lambda (v  )     (unsafe-setter v i j)))))
+                   ((1)  (lambda (i j)     (%%make-safer-array right-interval
+                                                               (lambda (    k)   (unsafe-getter   i j k))
+                                                               (lambda (v   k)   (unsafe-setter v i j k)))))
+                   ((2)  (lambda (i j)     (%%make-safer-array right-interval
+                                                               (lambda (    k l) (unsafe-getter   i j k l))
+                                                               (lambda (v   k l) (unsafe-setter v i j k l)))))
+                   (else (lambda (i j)     (%%make-safer-array right-interval
+                                                               (lambda      multi-index  (apply unsafe-getter   i j     multi-index))
+                                                               (lambda (v . multi-index) (apply unsafe-setter v i j     multi-index)))))))
            ((3)  (case (%%interval-dimension right-interval)
-                   ((0)  (lambda (i j k)   (make-array right-interval
-                                                       (lambda (     )   (getter   i j k))
-                                                       (lambda (v    )   (setter v i j k)))))
-                   ((1)  (lambda (i j k)   (make-array right-interval
-                                                       (lambda (      l) (getter   i j k l))
-                                                       (lambda (v     l) (setter v i j k l)))))
-                   (else (lambda (i j k)   (make-array right-interval
-                                                       (lambda      multi-index  (apply getter   i j k   multi-index))
-                                                       (lambda (v . multi-index) (apply setter v i j k   multi-index)))))))
+                   ((0)  (lambda (i j k)   (%%make-safer-array right-interval
+                                                               (lambda (     )   (unsafe-getter   i j k))
+                                                               (lambda (v    )   (unsafe-setter v i j k)))))
+                   ((1)  (lambda (i j k)   (%%make-safer-array right-interval
+                                                               (lambda (      l) (unsafe-getter   i j k l))
+                                                               (lambda (v     l) (unsafe-setter v i j k l)))))
+                   (else (lambda (i j k)   (%%make-safer-array right-interval
+                                                               (lambda      multi-index  (apply unsafe-getter   i j k   multi-index))
+                                                               (lambda (v . multi-index) (apply unsafe-setter v i j k   multi-index)))))))
            ((4)  (case (%%interval-dimension right-interval)
-                   ((0)  (lambda (i j k l) (make-array right-interval
-                                                       (lambda (     )   (getter   i j k l))
-                                                       (lambda (v    )   (setter v i j k l)))))
-                   (else (lambda (i j k l) (make-array right-interval
-                                                       (lambda      multi-index  (apply getter   i j k l multi-index))
-                                                       (lambda (v . multi-index) (apply setter v i j k l multi-index)))))))
+                   ((0)  (lambda (i j k l) (%%make-safer-array right-interval
+                                                               (lambda (     )   (unsafe-getter   i j k l))
+                                                               (lambda (v    )   (unsafe-setter v i j k l)))))
+                   (else (lambda (i j k l) (%%make-safer-array right-interval
+                                                               (lambda      multi-index  (apply unsafe-getter   i j k l multi-index))
+                                                               (lambda (v . multi-index) (apply unsafe-setter v i j k l multi-index)))))))
            (else (lambda left-multi-index
-                   (make-array right-interval
-                               (lambda      right-multi-index  (apply getter   (append left-multi-index right-multi-index)))
-                               (lambda (v . right-multi-index) (apply setter v (append left-multi-index right-multi-index)))))))
-         "array-curry: ")))))
+                   (%%make-safer-array right-interval
+                                       (lambda      right-multi-index  (apply unsafe-getter   (append left-multi-index right-multi-index)))
+                                       (lambda (v . right-multi-index) (apply unsafe-setter v (append left-multi-index right-multi-index))))))))))))
 
 (define (%%specialized-array-curry array right-dimension)
   (call-with-values
@@ -4067,7 +3852,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                                           (apply values
                                                  (append left-multi-index
                                                          right-multi-index)))))))))
-        (%%make-safe-immutable-array
+        (%%make-safer-array
          left-interval
          (case (%%interval-dimension left-interval)
            ((0)  (case (%%interval-dimension right-interval)
@@ -4096,8 +3881,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                    ((0)  (lambda (i j k l) (%%specialized-array-share array right-interval (lambda ()                            (values i j k l)) in-order?)))
                    (else (lambda (i j k l) (%%specialized-array-share array right-interval (lambda multi-index (apply values i j k l multi-index)) in-order?)))))
            (else (lambda left-multi-index
-                   (%%specialized-array-share array right-interval (lambda right-multi-index (apply values (append left-multi-index right-multi-index))) in-order?))))
-         "array-curry: ")))))
+                   (%%specialized-array-share array right-interval (lambda right-multi-index (apply values (append left-multi-index right-multi-index))) in-order?)))))))))
 
 (define (%%array-curry array right-dimension)
   (cond ((specialized-array? array)
@@ -4118,10 +3902,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ;;;
 ;;; array-map returns an array whose domain is the same as the common domain of (cons array arrays)
-;;; and whose getter is
+;;; and whose unsafe-getter is
 ;;;
 ;;; (lambda multi-index
-;;;   (apply f (map (lambda (g) (apply g multi-index)) (map array-getter (cons array arrays)))))
+;;;   (apply f (map (lambda (g) (apply g multi-index)) (map array-unsafe-getter (cons array arrays)))))
 ;;;
 ;;; This function is also used in array-for-each, so we try to specialize the this
 ;;; function to speed things up a bit.
@@ -4150,12 +3934,11 @@ OTHER DEALINGS IN THE SOFTWARE.
                                    args))))
 
       (define (do-one number-of-getters)
-        (let ((getters (map make-getter
-                            (iota number-of-getters))))
+        (let ((getters (map make-getter (iota number-of-getters))))
           `((,number-of-getters) (let ,(map (lambda (getter i)
-                                               `(,getter (%%array-getter (list-ref arrays ,i))))
-                                             getters
-                                             (iota number-of-getters))
+                                              `(,getter (%%array-unsafe-getter (list-ref arrays ,i))))
+                                            getters
+                                            (iota number-of-getters))
                                    (case (%%interval-dimension domain)
                                      ,@(map (lambda (dimension)
                                               (let ((multi-index (map (lambda (dim)
@@ -4174,7 +3957,7 @@ OTHER DEALINGS IN THE SOFTWARE.
              `(case (length arrays)
                 ,@(map do-one (iota (max-getters) 1))
                 (else
-                 (let ((getters (map array-getter arrays)))
+                 (let ((getters (map %%array-unsafe-getter arrays)))
                    (case (%%interval-dimension domain)
                      ,@(map (lambda (dimension)
                               (let ((multi-index (map (lambda (dim)
@@ -4192,8 +3975,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (define (%%array-map f array arrays)
   ;; unsafe, for internal use on known intervals
-  (make-array (%%array-domain array)
-              (%%specialize-function-applied-to-array-getters f array arrays)))
+  (%%make-safer-array (%%array-domain array)
+                      (%%specialize-function-applied-to-array-getters f array arrays)))
 
 (define (array-map f array #!rest arrays)
   (cond ((not (procedure? f))
@@ -4203,9 +3986,7 @@ OTHER DEALINGS IN THE SOFTWARE.
         ((not (%%every (lambda (d) (%%interval= d (%%array-domain array))) (map %%array-domain arrays)))
          (apply error "array-map: Not all arrays have the same domain: " f array arrays))
         (else
-         ;; safe
-         (make-array (%%array-domain array)
-                     (%%specialize-function-applied-to-array-getters f array arrays)))))
+         (%%array-map f array arrays))))
 
 ;;; applies f to the elements of the arrays in lexicographical order.
 
@@ -4364,9 +4145,9 @@ OTHER DEALINGS IN THE SOFTWARE.
         ((not (%%every (lambda (a) (%%interval= (%%array-domain a) (%%array-domain array))) arrays))
          (apply error "array-fold-left: Not all arrays have the same domain: " op id array arrays))
         ((null? arrays)
-         (%%interval-fold-left (%%array-getter array) op id (%%array-domain array)))
+         (%%interval-fold-left (%%array-unsafe-getter array) op id (%%array-domain array)))
         (else
-         (%%interval-fold-left (%%array-getter (%%array-map list array arrays))
+         (%%interval-fold-left (%%array-unsafe-getter (%%array-map list array arrays))
                                (case (length arrays)
                                  ((1) (lambda (id elements)
                                         (op id (car elements) (cadr elements))))
@@ -4388,9 +4169,9 @@ OTHER DEALINGS IN THE SOFTWARE.
         ((not (%%every (lambda (a) (%%interval= (%%array-domain a) (%%array-domain array))) arrays))
          (apply error "array-fold-right: Not all arrays have the same domain: " op id array arrays))
         ((null? arrays)
-         (%%interval-fold-right (%%array-getter array) op id (%%array-domain array)))
+         (%%interval-fold-right (%%array-unsafe-getter array) op id (%%array-domain array)))
         (else
-         (%%interval-fold-right (%%array-getter (%%array-map list array arrays))
+         (%%interval-fold-right (%%array-unsafe-getter (%%array-map list array arrays))
                                 (case (length arrays)
                                   ((1) (lambda (elements id)
                                          (op (car elements) (cadr elements) id)))
@@ -4407,7 +4188,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 (define %%array-reduce
   (let ((%%array-reduce-base (list 'base)))
     (lambda (sum A)
-      (%%interval-fold-left (%%array-getter A)
+      (%%interval-fold-left (%%array-unsafe-getter A)
                             (lambda (id a)
                               (if (eq? id %%array-reduce-base)
                                   a
@@ -4426,10 +4207,10 @@ OTHER DEALINGS IN THE SOFTWARE.
          (%%array-reduce sum A))))
 
 (define (%%array->reversed-list array)
-  ;; safe in the face of (%%array-getter array) capturing
+  ;; safe in the face of (%%array-unsafe-getter array) capturing
   ;; the continuation using call/cc, as long as the
   ;; resulting list is not modified.
-  (%%interval-fold-left (%%array-getter array)
+  (%%interval-fold-left (%%array-unsafe-getter array)
                         (lambda (a b) (cons b a))
                         '()
                         (%%array-domain array)))
@@ -4618,7 +4399,7 @@ OTHER DEALINGS IN THE SOFTWARE.
            (define (a->l a)
              (let ((dim (%%interval-dimension (%%array-domain a))))
                (case dim
-                 ((0) ((%%array-getter a)))  ;; special case, just the element of the array
+                 ((0) ((%%array-unsafe-getter a)))  ;; special case, just the element of the array
                  ((1) (%%array->list a))
                  (else
                   (%%array->list
@@ -4633,7 +4414,7 @@ OTHER DEALINGS IN THE SOFTWARE.
            (define (a->v a)
              (let ((dim (%%interval-dimension (%%array-domain a))))
                (case dim
-                 ((0) ((%%array-getter a)))  ;; special case, just the element of the array
+                 ((0) ((%%array-unsafe-getter a)))  ;; special case, just the element of the array
                  ((1) (%%array->vector a))
                  (else
                   (%%array->vector
@@ -4936,7 +4717,7 @@ OTHER DEALINGS IN THE SOFTWARE.
          (error (string-append caller "The fourth argument is not a boolean: ") A-arg storage-class mutable? safe?))
         (else
          (let* ((A   (array-copy A-arg))
-                (A_  (%%array-getter A))
+                (A_  (%%array-unsafe-getter A))
                 (A_D (%%array-domain A)))
            (if (not (%%array-every array? A '()))
                (error (string-append caller "Not all elements of the first argument (an array) are arrays: ") A-arg)
@@ -5034,10 +4815,10 @@ OTHER DEALINGS IN THE SOFTWARE.
                            (lambda (k)        ;; the direction
                              (let* ((pencil   ;; a pencil in that direction
                                      ;; Amazingly, this works when A_dim is 1.
-                                     (apply (%%array-getter (%%array-curry (%%array-permute A (%%index-last A_dim k)) 1))
+                                     (apply (%%array-unsafe-getter (%%array-curry (%%array-permute A (%%index-last A_dim k)) 1))
                                             (make-list (fx- A_dim 1) 0)))
                                     (pencil_
-                                     (%%array-getter pencil))
+                                     (%%array-unsafe-getter pencil))
                                     (pencil-size
                                      (%%interval-width (%%array-domain pencil) 0))
                                     (result   ;; include sum of all kth interval-widths in pencil
@@ -5060,7 +4841,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                                                      caller)
                               A))
                          (A_
-                          (%%array-getter A))
+                          (%%array-unsafe-getter A))
                          (result
                           (%%make-specialized-array
                            (make-interval

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -50,7 +50,6 @@ OTHER DEALINGS IN THE SOFTWARE.
    ("srfi/231#"
     ;; Internal SRFI 231 procedures that are either tested or called here.
     %%compose-indexers
-    make-%%array
     %%every
     %%interval->basic-indexer
     %%interval-lower-bounds
@@ -860,24 +859,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 (test (make-array (make-interval '#(3) '#(4)) list 1)
       "make-array: The third argument is not a procedure: ")
 
-(pp "array result tests")
-
 (define (myarray= array1 array2 #!optional (compare equal?))
   (and (interval= (array-domain array1)
                   (array-domain array2))
        (array-every compare array1 array2)))
-
-(let ((getter (lambda args 1.)))
-  (test (myarray= (make-array (make-interval '#(3) '#(4)) getter)
-                   (make-%%array (make-interval '#(3) '#(4))
-                                 getter
-                                 #f
-                                 #f
-                                 #f
-                                 #f
-                                 #f
-                                 %%order-unknown))
-        #t))
 
 (pp "array-domain and array-getter error tests")
 
@@ -898,27 +883,11 @@ OTHER DEALINGS IN THE SOFTWARE.
         #t)
   (test (array-domain array)
         domain)
-  (test (array-getter array)
+  ;; We now wrap the getter in checking code, so
+  ;; this test no longer passes
+  #;(test (array-getter array)
         getter))
 
-
-(pp "mutable-array result tests")
-
-(let ((result #f))
-  (let ((getter (lambda (i) result))
-        (setter   (lambda (v i) (set! result v)))
-        (domain   (make-interval '#(3) '#(4))))
-    (test (make-array domain
-                      getter
-                      setter)
-          (make-%%array domain
-                             getter
-                             setter
-                             #f
-                             #f
-                             #f
-                             #f
-                             %%order-unknown))))
 
 (pp "array-setter error tests")
 
@@ -940,9 +909,11 @@ OTHER DEALINGS IN THE SOFTWARE.
             #t)
       (test (mutable-array? 1)
             #f)
-      (test (array-setter array)
+      ;; We now wrap the getter and setter in checking code, so
+      ;; the next two no longer pass
+     #; (test (array-setter array)
             setter)
-      (test (array-getter array)
+      #;(test (array-getter array)
             getter)
       (test (array-domain array)
             domain))))
@@ -1880,9 +1851,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                   (if (storage-class-copier storage-class)
                       "Block copy"
                       "In order, no checks needed")
-                  (if (eq? storage-class generic-storage-class)
-                      "Out of order, no checks needed, generic-storage-class"
-                      "Out of order, no checks needed")))
+                  "Out of order, no checks"))
         (test (myarray= specialized-source (array-reverse specialized-destination))
               #t)
         ))))
@@ -1962,8 +1931,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                             (%%move-array-elements destination test-source "test: ")))
                       (and (equal? (if (not (specialized-array? test-source))
                                        (if (eq? destination-storage-class generic-storage-class)
-                                           "Checks not needed, source not specialized, generic-storage-class"
-                                           "Checks needed, source not specialized")
+                                           "Out of order, no checks"
+                                           "Out of order, checks")
                                        (if (array-packed? destination)
                                            (cond ((and (eq? destination-storage-class source-storage-class)
                                                        (storage-class-copier destination-storage-class))
@@ -1975,11 +1944,11 @@ OTHER DEALINGS IN THE SOFTWARE.
                                                  (else
                                                   "In order, checks needed"))
                                            (cond ((eq? destination-storage-class generic-storage-class)
-                                                  "Out of order, no checks needed, generic-storage-class")
+                                                  "Out of order, no checks")
                                                  ((%%every destination-checker (cdr (assq source-storage-class extreme-values-alist)))
-                                                  "Out of order, no checks needed")
+                                                  "Out of order, no checks")
                                                  (else
-                                                  "Out of order, checks needed"))))
+                                                  "Out of order, checks"))))
                                    %%move-result)
                            (myarray= destination
                                      test-source
@@ -1996,7 +1965,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                     #t)
               (test (let ((%%move-result
                            (%%move-array-elements generalized-destination source "test: ")))
-                      (and (equal? "Destination not specialized array"
+                      (and (equal? "Out of order, no checks"
                                    %%move-result)
                            (myarray= generalized-destination
                                      source
@@ -2410,6 +2379,22 @@ OTHER DEALINGS IN THE SOFTWARE.
                  (make-array (make-interval '#(3 4) '#(4 5))
                              list))
       "array-map: Not all arrays have the same domain: ")
+
+(do ((d 0 (+ d 1)))
+    ((= d 6))
+  (let* ((A (make-array (make-interval (make-vector d 3)) list))
+         (B (array-map length A)))
+    (test (apply (array-getter B) (make-list d 3))
+          (if (zero? d)  ;; zero copies of 3 is a valid multi-index
+              0
+              "array-getter: domain does not contain multi-index: "))
+    (test (apply (array-getter B) (make-list 6 2))
+          (if (= d 5)
+              ;; the actual getter is variadic, so it checks that the
+              ;; number of arguments is accurate itself
+              "array-getter: multi-index is not the correct dimension: "
+              ;; for d < 5 we rely on the built-in check
+              "Wrong number of arguments passed to procedure "))))
 
 (pp "array-every and array-any error tests")
 
@@ -2894,20 +2879,41 @@ OTHER DEALINGS IN THE SOFTWARE.
        (immutable (make-array domain list))
        (mutable   (make-array domain list list)) ;; nonsensical
        (special   (make-specialized-array domain)))
-  (do ((left-dim 1 (+ left-dim 1)))
+  (do ((left-dim 0 (+ left-dim 1)))
       ((> left-dim dim))
     (let* ((right-dim (- dim left-dim))
            (immutable-curry (array-curry immutable right-dim))
            (mutable-curry   (array-curry  mutable right-dim))
            (special-curry   (array-curry special right-dim)))
       (for-each (lambda (array)
-                  (test (apply array-ref array (make-list left-dim 100))
-                        "array-curry: domain does not contain multi-index: ")
-                  (test (apply array-ref array (make-list left-dim 'a))
-                        "array-curry: multi-index component is not an exact integer: ")
-                  (if (< 4 left-dim)
+                  (if (positive? left-dim)
+                      (begin
+                        (test (apply array-ref array (make-list left-dim 100))
+                              "array-getter: domain does not contain multi-index: ")
+                        (test (apply array-ref array (make-list left-dim 'a))
+                              "array-getter: multi-index component is not an exact integer: ")))
+                  (if (positive? right-dim)
+                      (begin
+                        (test (apply array-ref
+                                     (apply array-ref array (make-list left-dim 0))
+                                     (make-list right-dim 100))
+                              "array-getter: domain does not contain multi-index: ")
+                        (test (apply array-ref
+                                     (apply array-ref array (make-list left-dim 0))
+                                     (make-list right-dim 'a))
+                              "array-getter: multi-index component is not an exact integer: ")))
+                  (if (not (= 2 left-dim))
                       (test (apply array-ref array '(0 0))
-                            "array-curry: multi-index is not the correct dimension: ")))
+                            (if (< left-dim 5)
+                                "Wrong number of arguments passed to procedure "
+                                "array-getter: multi-index is not the correct dimension: ")))
+                  (if (not (= 2 right-dim))
+                      (test (apply array-ref
+                                   (apply array-ref array (make-list left-dim 0))
+                                   '(0 0))
+                            (if (< right-dim 5)
+                                "Wrong number of arguments passed to procedure "
+                                "array-getter: multi-index is not the correct dimension: "))))
                 (list immutable-curry mutable-curry special-curry)))))
 
 (let ((array-builders (vector (list u1-storage-class      (lambda indices (random (expt 2 1))))
@@ -3317,6 +3323,19 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (next-test-random-source-state!)
 
+(let* ((domain (make-interval '#(4 4)))
+       (specialized (array-copy (make-array domain list)))
+       (mutable (make-array domain list list)) ;; setter is nonsensical
+       (immutable (make-array domain list)))
+  (for-each (lambda (array)
+              (let ((translated (array-translate array '#(4 4))))
+                (test (array-ref translated 0 0)
+                      "array-getter: domain does not contain multi-index: ")
+                (if (mutable-array? translated)
+                    (test (array-set! translated 1 0 0)
+                          "array-setter: domain does not contain multi-index: "))))
+            (list specialized mutable immutable)))
+
 (let* ((specialized-array (array-copy (make-array (make-interval '#(0 0) '#(10 12))
                                                   list)))
        (mutable-array (let ((temp (array-copy specialized-array)))
@@ -3403,10 +3422,10 @@ OTHER DEALINGS IN THE SOFTWARE.
        (A (array-translate  mutable '#(0 0 0 0 0))))
 
   (test ((array-getter A) 0 0)
-        "The number of indices does not equal the array dimension: ")
+        "array-getter: multi-index is not the correct dimension: ")
 
   (test ((array-setter A) 'a 0 0)
-        "The number of indices does not equal the array dimension: "))
+        "array-setter: multi-index is not the correct dimension: "))
 
 
 (pp "interval and array permutation tests")
@@ -3589,6 +3608,19 @@ OTHER DEALINGS IN THE SOFTWARE.
                                   '#(1 0))
                    (make-array (make-interval '#(1 0)) error))
       #t)
+
+(let* ((domain (make-interval '#(2 4)))
+       (specialized (array-copy (make-array domain list)))
+       (mutable (make-array domain list list))
+       (immutable (make-array domain list)))
+  (for-each (lambda (array)
+              (let ((permuted (array-permute array '#(1 0))))
+                (test (array-ref permuted 1 3)
+                      "array-getter: domain does not contain multi-index: ")
+                (if (mutable-array? array)
+                    (test (array-set! permuted 1 1 3)
+                          "array-setter: domain does not contain multi-index: "))))
+            (list specialized mutable immutable)))
 
 (let* ((specialized-array (array-copy (make-array (make-interval '#(0 0) '#(10 12))
                                                                 list)))
@@ -3842,6 +3874,19 @@ OTHER DEALINGS IN THE SOFTWARE.
 (test (array-sample (make-array (make-interval '#(0) '#(2)) list) '#(2 1))
       "array-sample: The dimension of the first argument (an array) is not equal to the length of the second (a vector): ")
 
+(let* ((domain (make-interval '#(8)))
+       (specialized (array-copy (make-array domain list)))
+       (mutable (make-array domain list list))
+       (immutable (make-array domain list)))
+  (for-each (lambda (array)
+              (let ((sampled (array-sample array '#(3))))
+                (test (array-ref sampled 3)
+                      "array-getter: domain does not contain multi-index: ")
+                (if (mutable-array? sampled)
+                    (test (array-set! sampled 1 3)
+                          "array-setter: domain does not contain multi-index: "))))
+            (list specialized mutable immutable)))
+
 (define (myarray-sample array scales)
   (let ((scales-list (vector->list scales)))
     (cond ((specialized-array? array)
@@ -3921,13 +3966,27 @@ OTHER DEALINGS IN THE SOFTWARE.
   (test (mutable-array? B)
         #f))
 
-(let* ((A (make-specialized-array (make-interval '#(4 4))
-                                  generic-storage-class
-                                  #t     ;; mutable?
-                                  #t))   ;; safe?
-       (B (array-extract A (make-interval '#(2 2)))))
-  (test (array-ref B 2 2)
-        "array-getter: domain does not contain multi-index: "))
+(let* ((specialized
+        (make-specialized-array (make-interval '#(4 4))
+                                generic-storage-class
+                                #t     ;; mutable?
+                                #t))
+       (mutable
+        (make-array (array-domain specialized)
+                    (array-getter specialized)
+                    (array-setter specialized)))
+       (immutable
+        (make-array (array-domain specialized)
+                    (array-getter specialized))))
+  (for-each (lambda (array)
+              (let ((subarray
+                     (array-extract array (make-interval '#(2 2)))))
+                (test (array-ref subarray 2 2)
+                      "array-getter: domain does not contain multi-index: ")
+                (if (mutable-array? array)
+                    (test (array-set! subarray 'a 2 2)
+                          "array-setter: domain does not contain multi-index: "))))
+            (list specialized mutable immutable)))
 
 (do ((i 0 (fx+ i 1)))
     ((fx= i random-tests))
@@ -4025,12 +4084,12 @@ OTHER DEALINGS IN THE SOFTWARE.
          (B (array-tile A (make-vector d 10)))
          (index (make-list d 12)))
     (test (apply array-ref B (make-list d 12))
-          "array-tile: domain does not contain multi-index: ")
+          "array-getter: domain does not contain multi-index: ")
     (test (apply array-ref B (make-list d 'a))
-          "array-tile: multi-index component is not an exact integer: ")
+          "array-getter: multi-index component is not an exact integer: ")
     (if (< 4 d)
         (test (array-ref B 0 0 0 0)
-              "array-tile: multi-index is not the correct dimension: "))))
+              "array-getter: multi-index is not the correct dimension: "))))
 
 (define (ceiling-quotient x d)
   ;; assumes x and d are positive
@@ -4567,6 +4626,19 @@ OTHER DEALINGS IN THE SOFTWARE.
   (test ((array-getter A*B) 0 0 0 0) ;; outside of domain
         "array-getter: Array domain is empty: "))
 
+(let* ((domain (make-interval '#(4)))
+       (specialized (array-copy (make-array domain list)))
+       (immutable (make-array domain list))
+       (arrays (list specialized immutable)))
+  (for-each (lambda (A)
+              (for-each (lambda (B)
+                          (let ((array (array-outer-product append A B)))
+                            (test (array-ref array 10 3)
+                                  "array-getter: domain does not contain multi-index: ")
+                            (test (array-ref array 1 1 1 1)
+                                  "Wrong number of arguments passed to procedure ")))
+                        arrays))
+            arrays))
 
 (do ((i 0 (+ i 1)))
     ((= i random-tests))
@@ -6622,13 +6694,13 @@ that computes the componentwise products when we need them, the times are
 (let ((A (make-specialized-array (make-interval '#(5 5 5 5 5) '#(8 8 8 8 8))))
       (B (make-specialized-array (make-interval '#(5 5 5 5 5)))))
   (test (array-ref A 0 0)
-        "Wrong number of arguments passed to procedure ")
+        "array-getter: multi-index is not the correct dimension: ")
   (test (array-set! A 2 0 0)
-        "Wrong number of arguments passed to procedure ")
+        "array-setter: multi-index is not the correct dimension: ")
   (test (array-ref B 0 0)
-        "Wrong number of arguments passed to procedure ")
+        "array-getter: multi-index is not the correct dimension: ")
   (test (array-set! B 2 0 0)
-        "Wrong number of arguments passed to procedure "))
+        "array-setter: multi-index is not the correct dimension: "))
 
 (pp "Test interactions of continuations and array-{copy|append|stack|decurry|block}")
 


### PR DESCRIPTION
We add two hidden fields to arrays, %%array-unsafe-getter and %%array-unsafe-setter, which do no error checking.

We use these in all the bulk array processing routines, explicitly calling checkers in %%move-array-elements when needed.

This approach simplifies and speeds (somewhat) the routines.

generic-arrays.scm:

1.  Add two fields to %%array structure, unsafe-getter and unsafe-setter; assign new UUID as the id:

2.  Define %%make-safer-array, which takes a domain, unsafe-getter, and maybe an unsafe-setter, and wraps the unsafe getter and setter in checks to get the array's getter and setter.  Then builds the generalized array.  Use it in make-array and other places listed below.

3.  In array-freeze!, set the unsafe setter to #f.

4.  Remove the calls to (void) in storage-class-setters.

5.  Define %%wrap-getter-in-index-checks and %%wrap-setter-in-index-and-value-checks, use them in %%make-safer-array and %%finish-specialized-array

6.  In %%finish-specialized-array, define unsafe getter and setter, wrap them in checks to get the getter and setter.

7. Simplify %%move-array-elements, using the new unsafe getters and setters.

8.  %%immutable-array-extract and %%mutable-array-extract: build the new array with the unsafe getter and setters, call %%make-safer-array.

9. array-tile: call %%make-safer-array instead of %%make-safe-immutable-array.

10. %%array-translate, %%array-permute, %%array-reverse, %%{im}mutable-array-sample: Call %%make-safer-array with unsafe getter and setter.

11. %%array-outer-product: use unsafe getters, call %%make-safer-array

12. Remove %%make-safe-immutable-array, which is no longer used.

13. Use unsafe getters and setters in %%immutable-array-curry, %$mutable-array-curry, call %%make-safer-array. Similarly for %%specialized-array-curry.

14. %%specialize-function-applied-to-array-getters: specialize unsafe getters.

15. %%array-map: call %%make-safer-array, use unsafe getters.

16. array-fold-left, array-fold-right, array-reduce, %%array->reversed-list, array->list*, array->vector*, %%array-decurry, %%array-block: use unsafe getters

test-arrays.scm

1.  Update tests to check more invalid multi-indices in results of: array-curry, array-translate, array-permute, array-sample, array-extract, array-outer-product, array-map.  array-inner-product calls %%array-outer-product, so it's covered.

2.  Remove tests of make-%%array.

3.  Update tests of %%move-array-elements.

4.  In curry tests, also test for left dimension 0.